### PR TITLE
Use functools.wraps() instead of copying attributes

### DIFF
--- a/hypothesis/testdecorators.py
+++ b/hypothesis/testdecorators.py
@@ -1,3 +1,5 @@
+import functools
+
 from hypothesis.verifier import Verifier, Unfalsifiable, UnsatisfiedAssumption
 
 def given(*generator_arguments,**kwargs):
@@ -8,6 +10,7 @@ def given(*generator_arguments,**kwargs):
         verifier = Verifier()
 
     def run_test_with_generator(test):
+        @functools.wraps(test)
         def wrapped_test(*arguments):
             # The only thing we accept in falsifying the test are exceptions 
             # Returning successfully is always a pass.
@@ -30,7 +33,5 @@ def given(*generator_arguments,**kwargs):
             # Otherwise we would have swallowed all the reports of it actually
             # having gone wrong.
             test(*(arguments + falsifying_example[0]), **falsifying_example[1])
-        wrapped_test.__name__ = test.__name__
-        wrapped_test.__doc__  = test.__doc__
         return wrapped_test
     return run_test_with_generator


### PR DESCRIPTION
Hey, this is a great library.

Is there any reason for not using `functools.wraps()` ?

<https://docs.python.org/2/library/functools.html#functools.wraps>
<https://docs.python.org/3.4/library/functools.html#functools.wraps>