### PR TITLE
Encode path before inserting into sys.path.

### DIFF
--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -292,7 +292,7 @@ def eval_directory():
 
 def add_directory_to_path(d):
     if d not in sys.path:
-        sys.path.insert(0, d)
+        sys.path.insert(0, d.encode())
 
 
 eval_cache = {}


### PR DESCRIPTION
I noticed a bug with Hypothesis

Here is the minimum test case that reproduces it. Run with `py.test` to see the failure, commenting out `def test_foo(s)` to see the failure removed.

```python 
import os
import sys
import subprocess

import hypothesis

@hypothesis.given(str)
def test_foo(s):
    assert s == s


def test_subprocess():
    env = os.environ.copy()
    env["PYTHONPATH"] = os.pathsep.join(sys.path)
    subprocess.check_call(["ls", "-l"], env=env)
```
Here is the stack trace.
```
py.test                                                                                                           
============================= test session starts =============================                                     
platform win32 -- Python 2.7.9 -- py-1.4.26 -- pytest-2.7.0                                                         
rootdir: C:\Users\Terry\code\hypothesis-bug-repro, inifile:                                                         
plugins: hypothesis-pytest                                                                                          
collected 2 items                                                                                                   
                                                                                                                    
test_foo.py .F                                                                                                      
                                                                                                                    
================================== FAILURES ===================================                                     
_______________________________ test_subprocess _______________________________                                     
                                                                                                                    
    def test_subprocess():                                                                                          
        env = os.environ.copy()                                                                                     
        env["PYTHONPATH"] = os.pathsep.join(sys.path)                                                               
        pprint.pprint(env["PYTHONPATH"])                                                                            
>       subprocess.check_call(["ls", "-l"], env=env)                                                                
                                                                                                                    
test_foo.py:17:                                                                                                     
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                     
C:\Python27\Lib\subprocess.py:535: in check_call                                                                    
    retcode = call(*popenargs, **kwargs)                                                                            
C:\Python27\Lib\subprocess.py:522: in call                                                                          
    return Popen(*popenargs, **kwargs).wait()                                                                       
C:\Python27\Lib\subprocess.py:710: in __init__                                                                      
    errread, errwrite)                                                                                              
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _                                     
                                                                                                                    
self = <subprocess.Popen object at 0x02ECD910>, args = 'ls -l'                                                      
executable = None, preexec_fn = None, close_fds = False, cwd = None                                                 
env = {'ALLUSERSPROFILE': 'C:\\ProgramData', 'APPDATA': 'C:\\Users\\Terry\\AppData\\Roaming', 'ARCHITECTURE': '64', 
'ARGS': '--python=C:\\Python27\\python.exe throwaway', ...}                                                         
universal_newlines = False                                                                                          
startupinfo = <subprocess.STARTUPINFO instance at 0x02EB24E0>, creationflags = 0                                    
shell = False, to_close = set([]), p2cread = None, p2cwrite = None                                                  
c2pread = None, c2pwrite = None, errread = None, errwrite = None                                                    
                                                                                                                    
    def _execute_child(self, args, executable, preexec_fn, close_fds,                                               
                       cwd, env, universal_newlines,                                                                
                       startupinfo, creationflags, shell, to_close,                                                 
                       p2cread, p2cwrite,                                                                           
                       c2pread, c2pwrite,                                                                           
                       errread, errwrite):                                                                          
        """Execute program (MS Windows version)"""                                                                  
                                                                                                                    
        if not isinstance(args, types.StringTypes):                                                                 
            args = list2cmdline(args)                                                                               
                                                                                                                    
        # Process startup details                                                                                   
        if startupinfo is None:                                                                                     
            startupinfo = STARTUPINFO()                                                                             
        if None not in (p2cread, c2pwrite, errwrite):                                                               
            startupinfo.dwFlags |= _subprocess.STARTF_USESTDHANDLES                                                 
            startupinfo.hStdInput = p2cread                                                                         
            startupinfo.hStdOutput = c2pwrite                                                                       
            startupinfo.hStdError = errwrite                                                                        
                                                                                                                    
        if shell:                                                                                                   
            startupinfo.dwFlags |= _subprocess.STARTF_USESHOWWINDOW                                                 
            startupinfo.wShowWindow = _subprocess.SW_HIDE                                                           
            comspec = os.environ.get("COMSPEC", "cmd.exe")                                                          
            args = '{} /c "{}"'.format (comspec, args)                                                              
            if (_subprocess.GetVersion() >= 0x80000000 or                                                           
                    os.path.basename(comspec).lower() == "command.com"):                                            
                # Win9x, or using command.com on NT. We need to                                                     
                # use the w9xpopen intermediate program. For more                                                   
                # information, see KB Q150956                                                                       
                # (http://web.archive.org/web/20011105084002/http://support.microsoft.com/support/kb/articles/Q150/9
/56.asp)                                                                                                            
                w9xpopen = self._find_w9xpopen()                                                                    
                args = '"%s" %s' % (w9xpopen, args)                                                                 
                # Not passing CREATE_NEW_CONSOLE has been known to                                                  
                # cause random failures on win9x.  Specifically a                                                   
                # dialog: "Your program accessed mem currently in                                                   
                # use at xxx" and a hopeful warning about the                                                       
                # stability of your system.  Cost is Ctrl+C wont                                                    
                # kill children.                                                                                    
                creationflags |= _subprocess.CREATE_NEW_CONSOLE                                                     
                                                                                                                    
        def _close_in_parent(fd):                                                                                   
            fd.Close()                                                                                              
            to_close.remove(fd)                                                                                     
                                                                                                                    
        # Start the process                                                                                         
        try:                                                                                                        
            hp, ht, pid, tid = _subprocess.CreateProcess(executable, args,                                          
                                     # no special security                                                          
                                     None, None,                                                                    
                                     int(not close_fds),                                                            
                                     creationflags,                                                                 
                                     env,                                                                           
                                     cwd,                                                                           
>                                    startupinfo)                                                                   
E                                    TypeError: environment can only contain strings                                
                                                                                                                    
C:\Python27\Lib\subprocess.py:958: TypeError                                                                        
---------------------------- Captured stdout call -----------------------------                                     
u'C:\\Users\\Terry\\code\\hypothesis-bug-repro\\.hypothesis\\eval_source;C:\\Users\\Terry\\code\\hypothesis-bug-repr
o;C:\\Users\\Terry\\Envs\\throwaway\\Scripts;c:\\users\\terry\\code\\hypothesis\\src;C:\\Windows\\SYSTEM32\\python27
.zip;C:\\Users\\Terry\\Envs\\throwaway\\DLLs;C:\\Users\\Terry\\Envs\\throwaway\\lib;C:\\Users\\Terry\\Envs\\throwawa
y\\lib\\plat-win;C:\\Users\\Terry\\Envs\\throwaway\\lib\\lib-tk;C:\\Users\\Terry\\Envs\\throwaway\\Scripts;C:\\Pytho
n27\\Lib;C:\\Python27\\DLLs;C:\\Python27\\Lib\\lib-tk;C:\\Users\\Terry\\Envs\\throwaway;C:\\Users\\Terry\\Envs\\thro
waway\\lib\\site-packages'                                                                                          
===================== 1 failed, 1 passed in 0.46 seconds ======================                                     ```

I have sent you an email agreeing to the CLA if you want to merge this fix but any other solutions fixing this problem will be great as well! :)