### PR TITLE
Fix REPL formatting in example

### DIFF
--- a/docs/details.rst
+++ b/docs/details.rst
@@ -454,10 +454,10 @@ of list you want:
   >>> from collections import namedtuple
   >>> ListsOfFixedLength = namedtuple('ListsOfFixedLength', ('length', 'elements'))
   >>> @strategy.extend(ListsOfFixedLength)
-     ....: def fixed_length_lists_strategy(specifier, settings):
-     ....:     return strategy((specifier.elements,) * specifier.length, settings).map(
-     ....:        pack=list)
-     ....: 
+  ... def fixed_length_lists_strategy(specifier, settings):
+  ...     return strategy((specifier.elements,) * specifier.length, settings).map(
+  ...        pack=list)
+  ... 
   >>> strategy(ListsOfFixedLength(5, int)).example()
   [0, 2190, 899, 2, -1326]
 


### PR DESCRIPTION
This looks bad:
![screenshot](https://cloud.githubusercontent.com/assets/159967/6939360/9d4b6952-d874-11e4-8545-59176b2a3f3c.png)

especially compared with the previous example, which uses correct formatting:
![screenshot](https://cloud.githubusercontent.com/assets/159967/6939367/b3ae719e-d874-11e4-9eae-1f69ab5eb30e.png)
