### PR TITLE
HTTPS certificate fails for www.appveyor.com

### DIFF
--- a/docs/supported.rst
+++ b/docs/supported.rst
@@ -67,6 +67,6 @@ Regularly verifying this
 ------------------------
 
 Everything mentioned above as explicitly supported is checked on every commit 
-with `Travis <https://travis-ci.org/>`_ and `Appveyor <https://www.appveyor.com>`_
+with `Travis <https://travis-ci.org/>`_ and `Appveyor <http://www.appveyor.com>`_
 and goes green before a release happens, so when I say they're supported I really
 mean it.


### PR DESCRIPTION
They've either broken their https setup or don't intend to use it for the content site.

Login to https://ci.appveyor.com is configured correctly.