### PR TITLE
Support coroutine tests

### DIFF
--- a/tests/test_testdecorators.py
+++ b/tests/test_testdecorators.py
@@ -480,3 +480,16 @@ Litter = namedtuple('Litter', ('kitten1', 'kitten2'))
 @given(Litter(int, int))
 def test_named_tuples_are_of_right_type(litter):
     assert isinstance(litter, Litter)
+
+
+try:
+    import asyncio
+
+    @fails
+    @given(frozenset([int]))
+    @asyncio.coroutine
+    def test_coroutine(xs):
+        assert sum(xs) < 100
+        yield
+except ImportError:
+    pass


### PR DESCRIPTION
This allows to apply `@given` decorator to coroutine functions like this one:

```python
@given(str)
@asyncio.coroutine
def test_method(x):
    r = yield from aiohttp.request('GET', 'http://localhost', params={'foo': x})
    assert r.status == 200
```

See #52