### PR TITLE
Fix code blocks in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -72,7 +72,7 @@ data.
 
 Anyway, this test immediately finds a bug in the code:
 
-..
+.. code::
 
   Falsifying example: test_decode_inverts_encode(s='')
 
@@ -96,7 +96,7 @@ Suppose we had a more interesting bug and forgot to reset the count each time.
 
 Hypothesis quickly informs us of the following example:
 
-..
+.. code::
 
   Falsifying example: test_decode_inverts_encode(s='001')
 


### PR DESCRIPTION
When I look at [the quickstart docs](http://hypothesis.readthedocs.org/en/latest/quickstart.html), a few sections that should formated as code are not.

![screen shot 2015-04-08 at 7 59 13 am](https://cloud.githubusercontent.com/assets/1186124/7044812/64a3663a-ddc5-11e4-8e3d-7e04be17572d.png)

I fixed that.