### PR TITLE
Fix always-true assertion

### DIFF
--- a/tests/test_statistical_distribution.py
+++ b/tests/test_statistical_distribution.py
@@ -211,7 +211,7 @@ def test_puts_the_condition_in_the_error_message():
             condition=positive)()
     message = e.value.args[0]
     assert 'x == 0.0' in message
-    assert 'lambda not in message'
+    assert 'lambda' not in message
     assert 'rejected' in message
     assert 'positive' in message
 


### PR DESCRIPTION
I'm just guessing here, but I don't think you actually wanted an obfuscated `assert True` here in the middle of a test.

(I wonder if pyflakes/pylint picks up these?)