### PR TITLE
Emphasize that no examples were found

### DIFF
--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -50,7 +50,7 @@ class NoSuchExample(HypothesisException):
 
     def __init__(self, condition_string, extra=''):
         super(NoSuchExample, self).__init__(
-            'No examples of conditition %s%s' % (
+            'No examples found of conditition %s%s' % (
                 condition_string, extra)
         )
 


### PR DESCRIPTION
This information is clearly contained in the doc string already.