### PR TITLE
Catch ValidationError as well as IntegrityError

### DIFF
--- a/hypothesis-extra/hypothesis-django/src/hypothesisdjango/django/models.py
+++ b/hypothesis-extra/hypothesis-django/src/hypothesisdjango/django/models.py
@@ -117,5 +117,5 @@ class ModelStrategy(MappedSearchStrategy):
             result = self.model(**value)
             result.save()
             return result
-        except IntegrityError:
+        except (IntegrityError, ValidationError):
             assume(False)

--- a/hypothesis-extra/hypothesis-django/src/hypothesisdjango/django/models.py
+++ b/hypothesis-extra/hypothesis-django/src/hypothesisdjango/django/models.py
@@ -17,6 +17,7 @@ import django.db.models as dm
 import hypothesis.strategies as st
 import hypothesis.extra.fakefactory as ff
 from django.db import IntegrityError
+from django.core.exceptions import ValidationError
 from hypothesis.errors import InvalidArgument
 from hypothesis.control import assume
 from hypothesis.extra.datetime import datetimes


### PR DESCRIPTION
Certain Django fields enforce uniqueness on a class level, regardless of whether `unique` is specified in the field declaration. At least one of them, `UUIDField` from [django-extensions](https://django-extensions.readthedocs.org/en/latest/field_extensions.html#current-database-model-field-extensions), raises a `ValidationError` when uniqueness is violated. 

Thus, if two model examples containing a UUIDField are instantiated in a test, they will be instantiated with the same uuid value and the test will fail.

This patch treats ValidationError violations in a similar fashion as IntegrityError. 