### PR TITLE
Remove unused line of code in core.py

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -47,7 +47,6 @@ from hypothesis.internal.reflection import arg_string, copy_argspec, \
 from hypothesis.internal.examplesource import ParameterSource
 from hypothesis.searchstrategy.strategies import strategy
 
-[assume]
 
 
 def time_to_call_it_a_day(settings, start_time):


### PR DESCRIPTION
This line was added in 098b63e as a part of moving the assume function
to its own module, it looks to be left over from debugging or general
development clean-up.