### PR TITLE
add build status link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+|Build Status|
+
+.. |Build Status| image:: https://travis-ci.org/DRMacIver/hypothesis.svg
+   :target: https://travis-ci.org/DRMacIver/hypothesis
+
 ==========
 Hypothesis
 ==========


### PR DESCRIPTION
I've seen now that travis is failing for some interpreter but anyway I think it would be better to have the link easily accessible, so  other people can also help fixing the issues..