### PR TITLE
Small typo in license header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/examples/bintree.py
+++ b/examples/bintree.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-datetime/setup.py
+++ b/hypothesis-extra/hypothesis-datetime/setup.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-datetime/src/hypothesisdatetime/__init__.py
+++ b/hypothesis-extra/hypothesis-datetime/src/hypothesisdatetime/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-django/setup.py
+++ b/hypothesis-extra/hypothesis-django/setup.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-django/src/hypothesisdjango/__init__.py
+++ b/hypothesis-extra/hypothesis-django/src/hypothesisdjango/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-fakefactory/setup.py
+++ b/hypothesis-extra/hypothesis-fakefactory/setup.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-fakefactory/src/hypothesisfakefactory/__init__.py
+++ b/hypothesis-extra/hypothesis-fakefactory/src/hypothesisfakefactory/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-numpy/setup.py
+++ b/hypothesis-extra/hypothesis-numpy/setup.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-numpy/src/hypothesisnumpy/__init__.py
+++ b/hypothesis-extra/hypothesis-numpy/src/hypothesisnumpy/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-pytest/setup.py
+++ b/hypothesis-extra/hypothesis-pytest/setup.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-pytest/src/hypothesispytest/__init__.py
+++ b/hypothesis-extra/hypothesis-pytest/src/hypothesispytest/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-pytest/tests/test_capture.py
+++ b/hypothesis-extra/hypothesis-pytest/tests/test_capture.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-pytest/tests/test_mark.py
+++ b/hypothesis-extra/hypothesis-pytest/tests/test_mark.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-pytest/tests/test_reporting.py
+++ b/hypothesis-extra/hypothesis-pytest/tests/test_reporting.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/hypothesis-extra/hypothesis-pytest/tests/test_runs.py
+++ b/hypothesis-extra/hypothesis-pytest/tests/test_runs.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/scripts/header.py
+++ b/scripts/header.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/__init__.py
+++ b/src/hypothesis/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/control.py
+++ b/src/hypothesis/control.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/database/__init__.py
+++ b/src/hypothesis/database/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/database/backend.py
+++ b/src/hypothesis/database/backend.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/database/formats.py
+++ b/src/hypothesis/database/formats.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/deprecation.py
+++ b/src/hypothesis/deprecation.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/executors/__init__.py
+++ b/src/hypothesis/executors/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/executors/executors.py
+++ b/src/hypothesis/executors/executors.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/extra/__init__.py
+++ b/src/hypothesis/extra/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/extra/datetime.py
+++ b/src/hypothesis/extra/datetime.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/extra/django/__init__.py
+++ b/src/hypothesis/extra/django/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/extra/django/fixtures.py
+++ b/src/hypothesis/extra/django/fixtures.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/extra/django/models.py
+++ b/src/hypothesis/extra/django/models.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/extra/fakefactory.py
+++ b/src/hypothesis/extra/fakefactory.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/extra/numpy.py
+++ b/src/hypothesis/extra/numpy.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/__init__.py
+++ b/src/hypothesis/internal/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/chooser.py
+++ b/src/hypothesis/internal/chooser.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/classmap.py
+++ b/src/hypothesis/internal/classmap.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/compat.py
+++ b/src/hypothesis/internal/compat.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/debug.py
+++ b/src/hypothesis/internal/debug.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/distributions.py
+++ b/src/hypothesis/internal/distributions.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/examplesource.py
+++ b/src/hypothesis/internal/examplesource.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/tracker.py
+++ b/src/hypothesis/internal/tracker.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/internal/typechecking.py
+++ b/src/hypothesis/internal/typechecking.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/reporting.py
+++ b/src/hypothesis/reporting.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/__init__.py
+++ b/src/hypothesis/searchstrategy/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/basic.py
+++ b/src/hypothesis/searchstrategy/basic.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/flatmapped.py
+++ b/src/hypothesis/searchstrategy/flatmapped.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/misc.py
+++ b/src/hypothesis/searchstrategy/misc.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/morphers.py
+++ b/src/hypothesis/searchstrategy/morphers.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/narytree.py
+++ b/src/hypothesis/searchstrategy/narytree.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/numbers.py
+++ b/src/hypothesis/searchstrategy/numbers.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/recursive.py
+++ b/src/hypothesis/searchstrategy/recursive.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/reprwrapper.py
+++ b/src/hypothesis/searchstrategy/reprwrapper.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/strategies.py
+++ b/src/hypothesis/searchstrategy/strategies.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/streams.py
+++ b/src/hypothesis/searchstrategy/streams.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/strings.py
+++ b/src/hypothesis/searchstrategy/strings.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/searchstrategy/wrappers.py
+++ b/src/hypothesis/searchstrategy/wrappers.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/settings.py
+++ b/src/hypothesis/settings.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/specifiers.py
+++ b/src/hypothesis/specifiers.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/strategytests.py
+++ b/src/hypothesis/strategytests.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/testrunners/__init__.py
+++ b/src/hypothesis/testrunners/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/testrunners/forking.py
+++ b/src/hypothesis/testrunners/forking.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/tools/__init__.py
+++ b/src/hypothesis/tools/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/tools/mergedbs.py
+++ b/src/hypothesis/tools/mergedbs.py
@@ -5,7 +5,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/types.py
+++ b/src/hypothesis/types.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/utils/__init__.py
+++ b/src/hypothesis/utils/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/utils/conventions.py
+++ b/src/hypothesis/utils/conventions.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/utils/dynamicvariables.py
+++ b/src/hypothesis/utils/dynamicvariables.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/utils/extmethod.py
+++ b/src/hypothesis/utils/extmethod.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/utils/idkey.py
+++ b/src/hypothesis/utils/idkey.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/utils/show.py
+++ b/src/hypothesis/utils/show.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/utils/size.py
+++ b/src/hypothesis/utils/size.py
@@ -6,7 +6,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/src/hypothesis/version.py
+++ b/src/hypothesis/version.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/common/__init__.py
+++ b/tests/common/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/common/basic.py
+++ b/tests/common/basic.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/__init__.py
+++ b/tests/cover/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_bad_repr.py
+++ b/tests/cover/test_bad_repr.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_basic_strategy.py
+++ b/tests/cover/test_basic_strategy.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_chooser.py
+++ b/tests/cover/test_chooser.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_classmap.py
+++ b/tests/cover/test_classmap.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_collective_minimization.py
+++ b/tests/cover/test_collective_minimization.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_composite.py
+++ b/tests/cover/test_composite.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_control.py
+++ b/tests/cover/test_control.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_conventions.py
+++ b/tests/cover/test_conventions.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_converter.py
+++ b/tests/cover/test_converter.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_core.py
+++ b/tests/cover/test_core.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_database.py
+++ b/tests/cover/test_database.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_database_backend.py
+++ b/tests/cover/test_database_backend.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_deprecated_api.py
+++ b/tests/cover/test_deprecated_api.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_deprecation.py
+++ b/tests/cover/test_deprecation.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_descriptors.py
+++ b/tests/cover/test_descriptors.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_direct_strategies.py
+++ b/tests/cover/test_direct_strategies.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_distributions.py
+++ b/tests/cover/test_distributions.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_draw_example.py
+++ b/tests/cover/test_draw_example.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_dynamic_variable.py
+++ b/tests/cover/test_dynamic_variable.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_eval_as_source.py
+++ b/tests/cover/test_eval_as_source.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_examplesource.py
+++ b/tests/cover/test_examplesource.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_executors.py
+++ b/tests/cover/test_executors.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_exhaustion.py
+++ b/tests/cover/test_exhaustion.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_explicit_examples.py
+++ b/tests/cover/test_explicit_examples.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_extmethod.py
+++ b/tests/cover/test_extmethod.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_fancy_repr.py
+++ b/tests/cover/test_fancy_repr.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_filestorage.py
+++ b/tests/cover/test_filestorage.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_filtering.py
+++ b/tests/cover/test_filtering.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_find.py
+++ b/tests/cover/test_find.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_flatmap.py
+++ b/tests/cover/test_flatmap.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_float_nastiness.py
+++ b/tests/cover/test_float_nastiness.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_forking.py
+++ b/tests/cover/test_forking.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_given_error_conditions.py
+++ b/tests/cover/test_given_error_conditions.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_idkey.py
+++ b/tests/cover/test_idkey.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_imports.py
+++ b/tests/cover/test_imports.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_manual_given_invocation.py
+++ b/tests/cover/test_manual_given_invocation.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_morpher.py
+++ b/tests/cover/test_morpher.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_nary_tree.py
+++ b/tests/cover/test_nary_tree.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_nice_string.py
+++ b/tests/cover/test_nice_string.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_numerics.py
+++ b/tests/cover/test_numerics.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_one_of.py
+++ b/tests/cover/test_one_of.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_permutations.py
+++ b/tests/cover/test_permutations.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_recursive.py
+++ b/tests/cover/test_recursive.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_reflection.py
+++ b/tests/cover/test_reflection.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_reporting.py
+++ b/tests/cover/test_reporting.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_sampled_from.py
+++ b/tests/cover/test_sampled_from.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_searchstrategy.py
+++ b/tests/cover/test_searchstrategy.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_sets.py
+++ b/tests/cover/test_sets.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_settings.py
+++ b/tests/cover/test_settings.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_setup_teardown.py
+++ b/tests/cover/test_setup_teardown.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_simple_collections.py
+++ b/tests/cover/test_simple_collections.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_simple_numbers.py
+++ b/tests/cover/test_simple_numbers.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_simple_strings.py
+++ b/tests/cover/test_simple_strings.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_sizes.py
+++ b/tests/cover/test_sizes.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_strategytests.py
+++ b/tests/cover/test_strategytests.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_streams.py
+++ b/tests/cover/test_streams.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_tracker.py
+++ b/tests/cover/test_tracker.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_validation.py
+++ b/tests/cover/test_validation.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_verbosity.py
+++ b/tests/cover/test_verbosity.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_via_the_database.py
+++ b/tests/cover/test_via_the_database.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/cover/test_weird_settings.py
+++ b/tests/cover/test_weird_settings.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/datetime/__init__.py
+++ b/tests/datetime/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/datetime/test_datetime.py
+++ b/tests/datetime/test_datetime.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/datetime/test_details.py
+++ b/tests/datetime/test_details.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/__init__.py
+++ b/tests/django/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/manage.py
+++ b/tests/django/manage.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toys/__init__.py
+++ b/tests/django/toys/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toys/settings.py
+++ b/tests/django/toys/settings.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toys/urls.py
+++ b/tests/django/toys/urls.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toys/wsgi.py
+++ b/tests/django/toys/wsgi.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toystore/__init__.py
+++ b/tests/django/toystore/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toystore/admin.py
+++ b/tests/django/toystore/admin.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toystore/models.py
+++ b/tests/django/toystore/models.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toystore/test_basic_configuration.py
+++ b/tests/django/toystore/test_basic_configuration.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toystore/test_fixtures.py
+++ b/tests/django/toystore/test_fixtures.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toystore/test_given_models.py
+++ b/tests/django/toystore/test_given_models.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/django/toystore/views.py
+++ b/tests/django/toystore/views.py
@@ -5,7 +5,7 @@ from __future__ import division, print_function, absolute_import
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/fakefactory/__init__.py
+++ b/tests/fakefactory/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/fakefactory/test_fake_factory.py
+++ b/tests/fakefactory/test_fake_factory.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/__init__.py
+++ b/tests/nocover/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_compat.py
+++ b/tests/nocover/test_compat.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_debug.py
+++ b/tests/nocover/test_debug.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_descriptortests.py
+++ b/tests/nocover/test_descriptortests.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_example_quality.py
+++ b/tests/nocover/test_example_quality.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_floating.py
+++ b/tests/nocover/test_floating.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_git_merge.py
+++ b/tests/nocover/test_git_merge.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_statistical_distribution.py
+++ b/tests/nocover/test_statistical_distribution.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_strategy_state.py
+++ b/tests/nocover/test_strategy_state.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/nocover/test_streams.py
+++ b/tests/nocover/test_streams.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/numpy/__init__.py
+++ b/tests/numpy/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/numpy/test_gen_data.py
+++ b/tests/numpy/test_gen_data.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/py2/__init__.py
+++ b/tests/py2/__init__.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.

--- a/tests/py2/test_lambdas.py
+++ b/tests/py2/test_lambdas.py
@@ -3,7 +3,7 @@
 # This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
 
 # Most of this work is copyright (C) 2013-2015 David R. MacIver
-# (david@drmaciver.com), but it contains contributions by other. See
+# (david@drmaciver.com), but it contains contributions by others. See
 # https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
 # full list of people who may hold copyright, and consult the git log if you
 # need to determine who owns an individual contribution.


### PR DESCRIPTION
You may not want to merge this because it's relatively trivial, but it was the first thing I saw when I opened `reflection.py` and I couldn't un-see it.