### PR TITLE
Avoid races when execing source as modules.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -70,9 +70,10 @@ people have also contributed work. As well as my thanks, they also have copyrigh
 their individual contributions.
 
 * `Adam Sven Johnson <https://www.github.com/pkqk>`_
-* `Alex Stapleton <https://www.github.com/public>`_ 
-* `Charles O'Farrell <https://www.github.com/charleso>`_ 
+* `Alex Stapleton <https://www.github.com/public>`_
+* `Charles O'Farrell <https://www.github.com/charleso>`_
 * `Christopher Martin <https://www.github.com/chris-martin>`_ (`ch.martin@gmail.com <mailto:ch.martin@gmail.com>`_)
+* `Cory Benfield <https://www.github.com/Lukasa>`_
 * `Florian Bruhin <https://www.github.com/The-Compiler>`_
 * `follower <https://www.github.com/follower>`_
 * `Jonty Wareing <https://www.github.com/Jonty>`_ (`jonty@jonty.co.uk <mailto:jonty@jonty.co.uk>`_)

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -368,11 +368,13 @@ def source_exec_as_module(source):
         # The odds of final_filepath being a directory are basically zero, and
         # it's basically impossible for them to be on different filesystems, so
         # if this is raised it's because the destination already exists on
-        # Windows. That's fine, it won't be different, so just keep going.
+        # Windows. That's fine, it won't be different, so just keep going,
+        # deleting our tempfile.
         assert not os.path.isdir(final_filepath)
-        pass
+        os.remove(temporary_filepath)
 
     assert os.path.exists(final_filepath)
+    assert not os.path.exists(temporary_filepath)
     with open(final_filepath) as r:
         assert r.read() == source
     importlib_invalidate_caches()

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -364,7 +364,7 @@ def source_exec_as_module(source):
 
     try:
         os.rename(temporary_filepath, final_filepath)
-    except OSError:
+    except OSError:  # pragma: no cover
         # The odds of final_filepath being a directory are basically zero, and
         # it's basically impossible for them to be on different filesystems, so
         # if this is raised it's because the destination already exists on

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -24,8 +24,8 @@ import os
 import re
 import ast
 import sys
-import types
 import uuid
+import types
 import hashlib
 import inspect
 from functools import wraps

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -25,6 +25,7 @@ import re
 import ast
 import sys
 import types
+import uuid
 import hashlib
 import inspect
 from functools import wraps
@@ -347,18 +348,35 @@ def source_exec_as_module(source):
 
     d = eval_directory()
     add_directory_to_path(d)
-    name = u'hypothesis_temporary_module_%s' % (
+    final_name = u'hypothesis_temporary_module_%s' % (
         hashlib.sha1(source.encode(u'utf-8')).hexdigest(),
     )
-    filepath = os.path.join(d, name + u'.py')
-    f = open(filepath, u'w')
+    temporary_name = u'hypothesis_temporary_module_%s_%s' % (
+        hashlib.sha1(source.encode(u'utf-8')).hexdigest(),
+        uuid.uuid4(),
+    )
+    temporary_filepath = os.path.join(d, temporary_name + u'.py')
+    final_filepath = os.path.join(d, final_name + u'.py')
+    f = open(temporary_filepath, u'w')
     f.write(source)
     f.close()
-    assert os.path.exists(filepath)
-    with open(filepath) as r:
+    assert os.path.exists(temporary_filepath)
+
+    try:
+        os.rename(temporary_filepath, final_filepath)
+    except OSError:
+        # The odds of final_filepath being a directory are basically zero, and
+        # it's basically impossible for them to be on different filesystems, so
+        # if this is raised it's because the destination already exists on
+        # Windows. That's fine, it won't be different, so just keep going.
+        assert not os.path.isdir(final_filepath)
+        pass
+
+    assert os.path.exists(final_filepath)
+    with open(final_filepath) as r:
         assert r.read() == source
     importlib_invalidate_caches()
-    result = __import__(name)
+    result = __import__(final_name)
     eval_cache[source] = result
     return result
 


### PR DESCRIPTION
Resolves #143.

This change adjusts the logic when compiling source into a module and then importing it. Previously this could race, as multiple test processes running in parallel could attempt to write the same file at roughly the same time. This change prevents that by ensuring that each process writes to a unique file (by using a UUID4 in the filename), and then atomically renaming the file to the proper name.

On Windows this is a bit tricky because `os.rename` raises an `OSError` if the destination exists, so we allow for that. Otherwise, `os.rename` is atomic so this should be fine: no file should ever be empty.

Currently there are no tests here, I'm going to think about how best to test this, but I wanted the change up for review ASAP.

Consider this change a gift from your friends at HP!