### PR TITLE
Fix minor quirks in docs

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -241,7 +241,7 @@ returns a new strategy for it. So for example:
 
   >>> import hypothesis.strategies as st
   >>> json = st.recursive(st.floats() | st.booleans() | st.text() | st.none(),
-    lambda children: st.lists(children) | st.dictionaries(st.text(), children))
+  ... lambda children: st.lists(children) | st.dictionaries(st.text(), children))
   >>> json.example()
   {'': None, '\U000b3407\U000b3407\U000b3407': {
       '': '"é""é\x11', '\x13': 1.6153068016570349e-282,

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -646,7 +646,7 @@ def recursive(base, extend, max_leaves=100):
     base: A strategy to start from
     extend: A function which takes a strategy and returns a new strategy
     max_leaves: The maximum number of elements to be drawn from base on a given
-        run.
+    run.
 
     This returns a strategy S such that S = extend(base | S). That is, values
     maybe drawn from base, or from any strategy reachable by mixing


### PR DESCRIPTION
This was rendering poorly in read the docs making it hard to read.

This is what it looks on https://hypothesis.readthedocs.org/en/latest/data.html?highlight=recursive

<img width="579" alt="screen shot 2015-09-15 at 1 29 26 pm" src="https://cloud.githubusercontent.com/assets/1521093/9884462/d239e992-5bad-11e5-8348-d40700bf233e.png">


Here is after this change
<img width="747" alt="screen shot 2015-09-15 at 1 28 25 pm" src="https://cloud.githubusercontent.com/assets/1521093/9884444/bd5d72e6-5bad-11e5-91be-c37becb2fc87.png">

The second commit is just fixing a sphinx build error

![screen shot 2015-09-15 at 1 33 40 pm](https://cloud.githubusercontent.com/assets/1521093/9884568/6ae222f4-5bae-11e5-905f-40fab4ff5214.png)

Which cased the docs to look like this

<img width="702" alt="screen shot 2015-09-15 at 1 34 15 pm" src="https://cloud.githubusercontent.com/assets/1521093/9884580/7f32ece8-5bae-11e5-9048-92bc0e87c65a.png">

And now they look like this

<img width="713" alt="screen shot 2015-09-15 at 1 35 09 pm" src="https://cloud.githubusercontent.com/assets/1521093/9884608/a4b1ede8-5bae-11e5-867f-7538955c1261.png">

