### PR TITLE
Add close method to Backend interface

### DIFF
--- a/src/hypothesis/database/backend.py
+++ b/src/hypothesis/database/backend.py
@@ -58,6 +58,10 @@ class Backend(object):
     def fetch(self, key):
         """yield the values matching this key."""
 
+    @abstractmethod  # pragma: no cover
+    def close(self):
+        """Close database connection whenever such is used."""
+
 
 class SQLiteBackend(Backend):
 


### PR DESCRIPTION
This method is [used](https://github.com/DRMacIver/hypothesis/blob/e93399e2ae86951340cb39bc4658b052c85b7631/src/hypothesis/database/__init__.py#L89) by ExampleDatabase and custom backends should be aware about it.