### PR TITLE
Allow max examples to be an environment var

### DIFF
--- a/src/hypothesis/settings.py
+++ b/src/hypothesis/settings.py
@@ -278,7 +278,7 @@ search space.
 
 Settings.define_setting(
     u'max_examples',
-    default=200,
+    default=int(os.getenv(u'HYPOTHESIS_MAX_EXAMPLES', 200)),
     description="""
 Once this many satisfying examples have been considered without finding any
 counter-example, falsification will terminate.


### PR DESCRIPTION
Allowing this to be set via the environment enables a pattern of turning the value down during development where quick iteration is important and then turning the value up in a CI like environment.

If you like the change ill update the documentation. Otherwise no biggie.