### PR TITLE
Create profile loading mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ venv*
 .hypothesis
 docs/_build
 *.egg-info
+_build
+.tox
+.coverage

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,7 +111,7 @@ For example, it's super useful and higly appreciated if you do any of:
 * Build libraries and tools on top of Hypothesis outside the main repo
 
 Of, if you're OK with the pull request but don't feel quite ready to touch the code, you can always
-help to improve the documentation. Spot a tyop? Fix it up and send me a pull request! 
+help to improve the documentation. Spot a tyop? Fix it up and send me a pull request!
 
 If you need any help with any of these, get in touch and I'll be extremely happy to provide it.
 
@@ -135,6 +135,7 @@ their individual contributions.
 * `kbara <https://www.github.com/kbara>`_
 * `marekventur <https://www.github.com/marekventur>`_
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (`marius@gedmin.as <mailto:marius@gedmin.as>`_)
+* `Matt Bachmann <https://www.github.com/bachmann1234>`_ (`bachmann.matt@gmail.com <mailto:bachmann.matt@gmail.com>`_)
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (`richard@tartarus.org <mailto:richard@tartarus.org>`_)
 * `Saul Shanabrook <https://www.github.com/saulshanabrook>`_ (`s.shanabrook@gmail.com <mailto:s.shanabrook@gmail.com>`_)

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -285,6 +285,64 @@ You can also override the default by setting the environment variable
 setting ``HYPOTHESIS_VERBOSITY_LEVEL=verbose`` will run all your tests printing
 intermediate results and errors.
 
+.. _settings_profiles:
+
+~~~~~~~~~~~~~~~~~
+Settings Profiles
+~~~~~~~~~~~~~~~~~
+
+Depending on your environment you may want different default settings.
+For example: during development you may want to lower the number of examples
+to speed up the tests. However, in a CI environment you may want more examples
+so you are more likely to find bugs.
+
+Hypothesis allows you to define different settings profiles. These profiles
+can be loaded at any time.
+
+Loading a profile changes the default settings but will not change the behavior
+of tests that explicitly change the settings.
+
+.. code:: python
+
+    >>> from hypothesis import Settings
+    >>> Settings.register_profile("ci", Settings(max_examples=1000))
+    >>> Settings().max_examples
+    200
+    >>> Settings.load_profile("ci")
+    >>> Settings().max_examples
+    1000
+
+Instead of loading the profile and overriding the defaults you can retrieve profiles for
+specific tests.
+
+.. code:: python
+
+  >>> with Settings.get_profile("ci"):
+  ...     print(Settings().max_examples)
+  ...
+  1000
+
+Optionally, you may define the environment variable to load a profile for you.
+This is the suggested pattern for running your tests on CI.
+The code below should run in a `conftest.py` or any setup/initialization section of your test suite.
+If this variable is not defined the Hypothesis defined defaults will be loaded.
+
+.. code:: python
+
+    >>> from hypothesis import Settings
+    >>> Settings.register_profile("ci", Settings(max_examples=1000))
+    >>> Settings.register_profile("dev", Settings(max_examples=10))
+    >>> Settings.register_profile("debug", Settings(max_examples=10, verbosity=Verbosity.verbose))
+    >>> Settings.load_profile(os.getenv(u'HYPOTHESIS_PROFILE', 'default'))
+
+If you are using the hypothesis pytest plugin. If the profile was registered
+while loading in a conftest file you can load it with the command line
+option ``--hypothesis-profile``
+
+.. code:: bash
+
+    $ py.test tests --hypothesis-profile <profile-name>
+
 ---------------------
 Defining strategies
 ---------------------

--- a/docs/extras.rst
+++ b/docs/extras.rst
@@ -161,7 +161,7 @@ in as a providers argument:
     >>> class KittenProvider(BaseProvider):
     ...     def meows(self):
     ...             return 'meow %d' % (self.random_number(digits=10),)
-    ... 
+    ...
     >>> fake_factory('meows', providers=[KittenProvider]).example()
     'meow 9139348419'
 
@@ -192,5 +192,6 @@ package will remain for compatibility reasons if it does.
 
 hypothesis-pytest is the world's most basic pytest plugin. Install it to get
 slightly better integrated example reporting when using @given and running
-under pytest. That's basically all it does.
+under pytest.
 
+It can also load :ref:`Settings Profiles <settings_profiles>`.

--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -19,6 +19,9 @@ from __future__ import division, print_function, absolute_import
 import pytest
 
 PYTEST_VERSION = tuple(map(int, pytest.__version__.split('.')[:3]))
+LOAD_PROFILE_OPTION = '--hypothesis-profile'
+
+PYTEST_VERSION = tuple(map(int, pytest.__version__.split('.')))
 if PYTEST_VERSION >= (2, 7, 0):
     class StoringReporter(object):
 
@@ -30,6 +33,19 @@ if PYTEST_VERSION >= (2, 7, 0):
             if self.config.getoption('capture', 'fd') == 'no':
                 print(msg)
             self.results.append(msg)
+
+    def pytest_addoption(parser):
+        parser.addoption(
+            LOAD_PROFILE_OPTION,
+            action='store',
+            help='Load in a registered hypothesis settings profile'
+        )
+
+    def pytest_configure(config):
+        from hypothesis import settings
+        profile = config.getoption(LOAD_PROFILE_OPTION)
+        if profile:
+            settings.Settings.load_profile(profile)
 
     @pytest.mark.hookwrapper
     def pytest_pyfunc_call(pyfuncitem):

--- a/tests/pytest/test_profiles.py
+++ b/tests/pytest/test_profiles.py
@@ -1,0 +1,43 @@
+# coding=utf-8
+
+# This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
+
+# Most of this work is copyright (C) 2013-2015 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
+# full list of people who may hold copyright, and consult the git log if you
+# need to determine who owns an individual contribution.
+
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+from hypothesis.extra.pytestplugin import LOAD_PROFILE_OPTION
+
+pytest_plugins = str('pytester')
+
+CONFTEST = """
+from hypothesis.settings import Settings
+Settings.register_profile("test", Settings(max_examples=1))
+"""
+
+TESTSUITE = """
+from hypothesis import given
+from hypothesis.strategies import integers
+from hypothesis.settings import Settings
+
+def test_this_one_is_ok():
+    assert Settings().max_examples == 1
+"""
+
+
+def test_runs_reporting_hook(testdir):
+    script = testdir.makepyfile(TESTSUITE)
+    testdir.makeconftest(CONFTEST)
+    result = testdir.runpytest(script, LOAD_PROFILE_OPTION, 'test')
+    out = '\n'.join(result.stdout.lines)
+    assert '1 passed' in out


### PR DESCRIPTION
Allows users to register settings profiles and load them
in as needed. Allowing for different defaults for different
environments

Is this kind of what you were thinking for the profile setup?

This code should enable the following pattern

```
Settings.register_profile('dev', max_examples=5, max_shrinks=10, max_iterations=100)
Settings.register_profile('ci', max_examples=1000, max_shrinks=1000, max_iterations=2000)

Settings.load_profile(os.getenv('HYPOTHESIS_PROFILE', 'default'))
```

If you think im close ill iterate with you as needed. If we get to something you like let me know and ill write up the docs.