### PR TITLE
Implement characters strategy

### DIFF
--- a/src/hypothesis/internal/charstree.py
+++ b/src/hypothesis/internal/charstree.py
@@ -1,0 +1,310 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
+#
+# Most of this work is copyright (C) 2013-2015 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
+# full list of people who may hold copyright, and consult the git log if you
+# need to determine who owns an individual contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import os
+import sys
+import zlib
+import bisect
+import functools
+import itertools
+import unicodedata
+
+import marshal
+from hypothesis.errors import InvalidArgument
+from hypothesis.settings import hypothesis_home_dir
+from hypothesis.internal.compat import hrange, hunichr
+
+__all__ = (
+    'ascii_tree',
+    'unicode_tree',
+    'categories',
+    'category_by_codepoint',
+    'codepoints',
+    'codepoints_for_category',
+    'filter_tree',
+    'random_codepoint',
+)
+
+
+ASCII_TREE = {}
+UNICODE_TREE = {}
+
+
+def ascii_tree():
+    """Returns tree for ASCII characters."""
+    global ASCII_TREE
+    if not ASCII_TREE:
+        ASCII_TREE = filter_tree(unicode_tree(), max_codepoint=127)
+    return ASCII_TREE
+
+
+def unicode_tree():
+    """Returns tree of Unicode characters."""
+    global UNICODE_TREE
+    if not UNICODE_TREE:
+        try:
+            UNICODE_TREE = load_tree()
+        except:
+            UNICODE_TREE = make_tree()
+            try:
+                dump_tree(UNICODE_TREE)
+            except:  # pragma: no cover
+                pass
+    return UNICODE_TREE
+
+
+def categories(tree):
+    """Returns list of all categories in specified tree."""
+    return list(tree)
+
+
+def category_by_codepoint(tree, codepoint):
+    """Returns category by specified code point in the tree."""
+    categories = list(filter_tree(
+        tree, min_codepoint=codepoint, max_codepoint=codepoint))
+    if not categories:
+        return None
+    assert len(categories) == 1
+    return categories[0]
+
+
+def codepoints(tree):
+    """Iterates over all code points in specified tree.
+
+    Code points get yielded in single stream category by category.
+
+    """
+    by_category = functools.partial(codepoints_for_category, tree)
+    return itertools.chain.from_iterable(map(by_category, categories(tree)))
+
+
+def codepoints_for_category(tree, category):
+    """Iterates over all code points of the specified category in the tree."""
+    for value in iter_values(tree[category]):
+        for cp in hrange(value[0], value[1] + 1):
+            yield cp
+
+
+def random_codepoint(tree, category, random):
+    """Returns random code point for specified category in the tree."""
+    base, values = select_values(
+        tree, category, lambda ns: random.choice(list(ns)))
+    assert values, 'no values found'
+    value = random.choice(values)
+    if value[0] == value[1]:
+        return base + value[0]
+    return random.randint(base + value[0], base + value[1])
+
+
+def filter_tree(tree, whitelist_categories=None, blacklist_categories=None,
+                blacklist_characters=None, min_codepoint=0,
+                max_codepoint=sys.maxunicode):
+    """Filters tree by Unicode categories and code points range."""
+    if whitelist_categories and blacklist_categories:
+        raise InvalidArgument('cannot have both white and black list of'
+                              ' categories at the same time')
+
+    if min_codepoint > max_codepoint:
+        raise InvalidArgument('min code point is greater than max')
+
+    categories = set(tree)
+    if whitelist_categories:
+        categories &= set(whitelist_categories)
+    if blacklist_categories:
+        categories -= set(blacklist_categories)
+    if not blacklist_characters:
+        blacklist_characters = set([])
+
+    return do_filter_tree(tree, categories, blacklist_characters,
+                          min_codepoint, max_codepoint)
+
+
+def do_filter_tree(tree, categories, blacklist_characters,
+                   min_codepoint, max_codepoint):
+    new_tree = {}
+    for key, subtree in tree.items():
+        if key not in categories:
+            continue
+
+        subtree = do_filter_tree_by_codepoints(
+            subtree, min_codepoint, max_codepoint, {}, 0)
+
+        if not subtree:
+            continue
+
+        subtree = do_filter_tree_by_characters(
+            subtree, sorted(blacklist_characters), {}, 0)
+
+        if not subtree:
+            continue
+
+        new_tree[key] = subtree
+
+    return new_tree
+
+
+def do_filter_tree_by_codepoints(tree, min_codepoint, max_codepoint,
+                                 acc, base):
+    for key, value in tree.items():
+        this_base = base + key
+
+        if this_base > max_codepoint:
+            continue
+
+        if isinstance(value, dict):
+            subtree = do_filter_tree_by_codepoints(
+                value, min_codepoint, max_codepoint, {}, this_base)
+            if subtree:
+                acc[key] = subtree
+
+        else:
+            filtered_items = []
+
+            for item in value:
+                if item[0] + this_base > max_codepoint:
+                    continue
+                if item[1] + this_base < min_codepoint:
+                    continue
+                if item[0] + this_base < min_codepoint:
+                    item = (min_codepoint - this_base, item[1])
+                if item[1] + this_base > max_codepoint:
+                    item = (item[0], max_codepoint - this_base)
+                filtered_items.append(item)
+
+            if filtered_items:
+                acc[key] = tuple(filtered_items)
+
+    return acc
+
+
+def do_filter_tree_by_characters(tree, blacklist_characters, acc, base):
+    if not blacklist_characters:
+        return tree
+
+    for key, value in tree.items():
+        this_base = base + key
+
+        index = bisect.bisect(blacklist_characters, hunichr(this_base))
+        characters = blacklist_characters[index - 1 if index else 0:]
+
+        if isinstance(value, dict):
+            subtree = do_filter_tree_by_characters(
+                value, characters, {}, this_base)
+            if subtree:
+                acc[key] = subtree
+        else:
+            filtered_value = value
+            for character in characters:
+                codepoint = ord(character)
+                value_acc = []
+                for item in filtered_value:
+                    locp, hicp = item[0] + this_base, item[1] + this_base
+                    if locp == codepoint == hicp:
+                        continue
+                    elif not (locp <= codepoint <= hicp):
+                        value_acc.append(item)
+                    elif locp == codepoint:
+                        item = (codepoint + 1 - this_base, item[1])
+                        value_acc.append(item)
+                    elif hicp == codepoint:
+                        item = (item[0], codepoint - 1 - this_base)
+                        value_acc.append(item)
+                    else:
+                        value_acc.append((item[0], codepoint - 1 - this_base))
+                        value_acc.append((codepoint + 1 - this_base, item[1]))
+                filtered_value = value_acc
+            if filtered_value:
+                acc[key] = tuple(filtered_value)
+    return acc
+
+
+def select_values(tree, category, selector):
+    if category not in tree:
+        return 0, []
+    base = 0
+    namespace = tree[category]
+    while True:
+        key = selector(namespace)
+        namespace = namespace[key]
+        base += key
+        if isinstance(namespace, dict):
+            continue
+        return base, namespace
+
+
+def iter_values(namespace, base=0):
+    if isinstance(namespace, dict):
+        for key in namespace:
+            for value in iter_values(namespace[key], base + key):
+                yield value
+    else:
+        for value in namespace:
+            yield (base + value[0], base + value[1])
+
+
+def make_tree():
+    def new_tree():
+        tree = {}
+        for codepoint in hrange(0, sys.maxunicode + 1):
+            cat = unicodedata.category(hunichr(codepoint))
+            target = tree.setdefault(cat, [])
+            if target and codepoint == target[-1][-1] + 1:
+                target[-1][-1] += 1
+            else:
+                target.append([codepoint, codepoint])
+        return tree
+
+    def fold(tree, factor):
+        for key, values in tree.items():
+            if isinstance(values, dict):
+                fold(values, factor)
+            else:
+                tree[key] = fold_values(values, factor)
+
+    def fold_values(values, factor):
+        group = {}
+        by_factor = lambda i: i[0] & factor
+        for ns, items in itertools.groupby(values, key=by_factor):
+            namespace = group.setdefault(ns, [])
+            namespace.extend([[i[0] - ns, i[1] - ns] for i in items])
+        return group
+
+    tree = new_tree()
+    # Multi folding optimizes file size ~10-15% and improves algorithmic cost
+    # of code point lookup
+    fold(tree, 0xfff000)
+    fold(tree, 0xffff00)
+    fold(tree, 0xfffff0)
+    return tree
+
+
+def cache_file_path():
+    return os.path.join(hypothesis_home_dir(),
+                        os.path.basename(__file__) + '.cache')
+
+
+def dump_tree(tree):  # pragma: no cover
+    dump = marshal.dumps(tree, version=2)
+    with open(cache_file_path(), 'wb') as f:
+        f.write(zlib.compress(dump))
+
+
+def load_tree():  # pragma: no cover
+    with open(cache_file_path(), 'rb') as f:
+        dump = zlib.decompress(f.read())
+    return marshal.loads(dump)

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -34,7 +34,7 @@ __all__ = [
     'choices',
     'booleans', 'integers', 'floats', 'complex_numbers', 'fractions',
     'decimals',
-    'text', 'binary',
+    'characters', 'text', 'binary',
     'tuples', 'lists', 'sets', 'frozensets',
     'dictionaries', 'fixed_dictionaries',
     'sampled_from',
@@ -532,6 +532,32 @@ def streaming(elements):
 
 
 @defines_strategy
+def characters(whitelist_categories=None, blacklist_categories=None,
+               blacklist_characters=None, min_codepoint=None,
+               max_codepoint=None):
+    """Generates unicode text type (unicode on python 2, str on python 3)
+    characters following specified filtering rules.
+
+    This strategy accepts lists of Unicode categories, characters of which
+    should (`whitelist_categories`) or should not (`blacklist_categories`)
+    be produced.
+
+    Also there could be applied limitation by minimal and maximal produced
+    code point of the characters.
+
+    If you know what exactly characters you don't want to be produced,
+    pass them with `blacklist_characters` argument.
+
+    """
+    from hypothesis.searchstrategy.strings import OneCharStringStrategy
+    return OneCharStringStrategy(whitelist_categories=whitelist_categories,
+                                 blacklist_categories=blacklist_categories,
+                                 blacklist_characters=blacklist_characters,
+                                 min_codepoint=min_codepoint,
+                                 max_codepoint=max_codepoint)
+
+
+@defines_strategy
 def text(
     alphabet=None,
     min_size=None, average_size=None, max_size=None
@@ -548,7 +574,7 @@ def text(
     from hypothesis.searchstrategy.strings import OneCharStringStrategy, \
         StringStrategy
     if alphabet is None:
-        char_strategy = OneCharStringStrategy()
+        char_strategy = OneCharStringStrategy(blacklist_categories=['Cs'])
     elif not alphabet:
         if (min_size or 0) > 0:
             raise InvalidArgument(

--- a/tests/cover/test_charstree.py
+++ b/tests/cover/test_charstree.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
+#
+# Most of this work is copyright (C) 2013-2015 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
+# full list of people who may hold copyright, and consult the git log if you
+# need to determine who owns an individual contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import, \
+    unicode_literals
+
+import sys
+import random
+import unicodedata
+
+import pytest
+
+from hypothesis.internal import charstree
+from hypothesis.internal.compat import hunichr
+
+
+def test_ascii_tree():
+    tree = charstree.ascii_tree()
+    assert isinstance(tree, dict)
+
+
+def test_unicode_tree():
+    tree = charstree.unicode_tree()
+    assert isinstance(tree, dict)
+
+
+def test_ascii_tree_categories():
+    tree = charstree.ascii_tree()
+    expected = list(set([unicodedata.category(hunichr(i))
+                         for i in range(0, 128)]))
+    actual = charstree.categories(tree)
+    assert sorted(expected) == sorted(actual)
+
+
+def test_unicode_tree_categories():
+    tree = charstree.unicode_tree()
+    expected = list(set([unicodedata.category(hunichr(i))
+                         for i in range(0, sys.maxunicode + 1)]))
+    actual = charstree.categories(tree)
+    assert sorted(expected) == sorted(actual)
+
+
+def test_ascii_tree_codepoints():
+    tree = charstree.ascii_tree()
+    expected = list(range(0, 128))
+    actual = sorted(list(charstree.codepoints(tree)))
+    assert expected == actual
+
+
+def test_unicode_tree_codepoints():
+    tree = charstree.unicode_tree()
+    expected = list(range(0, sys.maxunicode + 1))
+    actual = sorted(list(charstree.codepoints(tree)))
+    assert expected == actual
+
+
+def test_category_by_codepoint():
+    tree = charstree.unicode_tree()
+    assert 'Nd' == charstree.category_by_codepoint(tree, ord(u'1'))
+    assert 'Ll' == charstree.category_by_codepoint(tree, ord(u'я'))
+
+    tree = charstree.ascii_tree()
+    assert charstree.category_by_codepoint(tree, ord(u'я')) is None
+
+
+def test_filter_tree():
+    tree = charstree.ascii_tree()
+    new_tree = charstree.filter_tree(
+        tree, min_codepoint=ord('0'), max_codepoint=ord('9'))
+    expected = list(range(ord('0'), ord('9') + 1))
+    actual = list(charstree.codepoints(new_tree))
+    assert expected == actual
+
+
+def test_assert_on_searching_random_codepoint_for_empty_tree():
+    with pytest.raises(AssertionError):
+        charstree.random_codepoint({}, '-', random)

--- a/tests/cover/test_simple_characters.py
+++ b/tests/cover/test_simple_characters.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+#
+# This file is part of Hypothesis (https://github.com/DRMacIver/hypothesis)
+#
+# Most of this work is copyright (C) 2013-2015 David R. MacIver
+# (david@drmaciver.com), but it contains contributions by others. See
+# https://github.com/DRMacIver/hypothesis/blob/master/CONTRIBUTING.rst for a
+# full list of people who may hold copyright, and consult the git log if you
+# need to determine who owns an individual contribution.
+#
+# This Source Code Form is subject to the terms of the Mozilla Public License,
+# v. 2.0. If a copy of the MPL was not distributed with this file, You can
+# obtain one at http://mozilla.org/MPL/2.0/.
+#
+# END HEADER
+
+from __future__ import division, print_function, absolute_import
+
+import unicodedata
+
+import pytest
+
+from hypothesis import find
+from hypothesis.errors import NoSuchExample, InvalidArgument
+from hypothesis.strategies import characters
+
+
+def test_bad_category_arguments():
+    with pytest.raises(InvalidArgument):
+        characters(whitelist_categories=['foo'], blacklist_categories=['bar'])
+
+
+def test_bad_codepoint_arguments():
+    with pytest.raises(InvalidArgument):
+        characters(min_codepoint=42, max_codepoint=24)
+
+
+def test_exclude_all_available_range():
+    with pytest.raises(InvalidArgument):
+        characters(min_codepoint=ord('0'), max_codepoint=ord('0'),
+                   blacklist_characters='0')
+
+
+def test_when_nothing_could_be_produced():
+    with pytest.raises(InvalidArgument):
+        characters(whitelist_categories=['Cc'],
+                   min_codepoint=ord('0'), max_codepoint=ord('9'))
+
+
+def test_characters_of_specific_groups():
+    st = characters(whitelist_categories=('Lu', 'Nd'))
+
+    find(st, lambda c: unicodedata.category(c) == 'Lu')
+    find(st, lambda c: unicodedata.category(c) == 'Nd')
+
+    with pytest.raises(NoSuchExample):
+        find(st, lambda c: unicodedata.category(c) not in ('Lu', 'Nd'))
+
+
+def test_exclude_characters_of_specific_groups():
+    st = characters(blacklist_categories=('Lu', 'Nd'))
+
+    find(st, lambda c: unicodedata.category(c) != 'Lu')
+    find(st, lambda c: unicodedata.category(c) != 'Nd')
+
+    with pytest.raises(NoSuchExample):
+        find(st, lambda c: unicodedata.category(c) in ('Lu', 'Nd'))
+
+
+def test_find_one():
+    char = find(characters(min_codepoint=48, max_codepoint=48), lambda _: True)
+    assert char == u'0'
+
+
+def test_find_something_rare():
+    st = characters(whitelist_categories=['Zs'], min_codepoint=12288)
+
+    find(st, lambda c: unicodedata.category(c) == 'Zs')
+
+    with pytest.raises(NoSuchExample):
+        find(st, lambda c: unicodedata.category(c) != 'Zs')
+
+
+def test_blacklisted_characters():
+    bad_chars = u'te02тест49st'
+    st = characters(min_codepoint=ord('0'), max_codepoint=ord('9'),
+                    blacklist_characters=bad_chars)
+
+    assert '1' == find(st, lambda c: True)
+
+    with pytest.raises(NoSuchExample):
+        find(st, lambda c: c in bad_chars)


### PR DESCRIPTION
This strategy allows to produce single unicode characters by specified rules: you may have exact characters or characters that belongs some [Unicode Category](http://www.unicode.org/reports/tr44/#General_Category_Values). Additionally, you may reverse your rule to specify which characters you don't want to get.

characters strategy preserved existed OneCharStringStrategy behaviour when with no arguments it produces all the characters except surrogates.

characters with exact only argument converted into sampled_from strategy implicitly.

Generally tests passed, but travis fails due to irrelevant reasons. What I can fix will send with additional PRs. 

Feedback is welcome (: