### PR TITLE
Better error when decorating a function with destructuring args

### DIFF
--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -432,6 +432,12 @@ def given(*generator_arguments, **generator_kwargs):
         specifiers = list(generator_arguments)
         seen_kwarg = None
         for a in arguments:
+            if isinstance(a, list):
+                raise InvalidArgument((
+                    u'Cannot decorate function %s() because it has '
+                    u'destructuring arguments') % (
+                        test.__name__,
+                ))
             if a in generator_kwargs:
                 seen_kwarg = seen_kwarg or a
                 specifiers.append(generator_kwargs[a])

--- a/src/hypothesis/core.py
+++ b/src/hypothesis/core.py
@@ -432,7 +432,7 @@ def given(*generator_arguments, **generator_kwargs):
         specifiers = list(generator_arguments)
         seen_kwarg = None
         for a in arguments:
-            if isinstance(a, list):
+            if isinstance(a, list):  # pragma: no cover
                 raise InvalidArgument((
                     u'Cannot decorate function %s() because it has '
                     u'destructuring arguments') % (

--- a/tests/py2/test_destructuring.py
+++ b/tests/py2/test_destructuring.py
@@ -16,9 +16,20 @@
 
 from __future__ import division, print_function, absolute_import
 
+import pytest
+from hypothesis import given
+from hypothesis.errors import InvalidArgument
+from hypothesis.strategies import integers
 from hypothesis.internal.reflection import get_pretty_function_description
 
 
 def test_destructuring_lambdas():
     assert get_pretty_function_description(lambda (x, y): 1) == \
         u'lambda (x, y): <unknown>'
+
+
+def test_destructuring_not_allowed():
+    with pytest.raises(InvalidArgument):
+        @given(integers())
+        def foo(a, (b, c)):
+            pass


### PR DESCRIPTION
Instead of `TypeError: unhashable type: 'list'` when we try operate on them.