### PR TITLE
Correct several spelling errors discovered with scspell

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -103,7 +103,7 @@ If Pull Requests put you off
 If you don't feel able to contribute code to Hypothesis that's *100% OK*. There
 are lots of other things you can do to help too!
 
-For example, it's super useful and higly appreciated if you do any of:
+For example, it's super useful and highly appreciated if you do any of:
 
 * Submit bug reports
 * Submit feature requests

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -24,7 +24,7 @@ File locations
 The default (and currently only) storage format is as rather weirdly unidiomatic JSON saved
 in an sqlite3 database. The standard location for that is .hypothesis/examples.db in your current
 working directory. You can override this, either by setting either the database\_file property on
-a Settings object (you probably want to specifiy it on Settings.default) or by setting the
+a Settings object (you probably want to specify it on Settings.default) or by setting the
 HYPOTHESIS\_DATABASE\_FILE environment variable.
 
 Note: There are other files in .hypothesis but everything other than the examples.db will be

--- a/docs/details.rst
+++ b/docs/details.rst
@@ -548,7 +548,7 @@ will be turned into an AbnormalExit exception.
 
 There are currently some limitations to this approach:
 
-1. Exceptions which are not pickleable will be turned into abormal exits.
+1. Exceptions which are not pickleable will be turned into abnormal exits.
 2. Tracebacks from exceptions are not properly recreated in the parent process.
 3. Code called in the child process will not be recorded by coverage.
 4. This is only supported on platforms with os.fork. e.g. it will not work on
@@ -587,12 +587,12 @@ example to a condition that is always false it will raise an error:
   >>> find(integers(), lambda x: False)
   Traceback (most recent call last):
   ...
-  hypothesis.errors.NoSuchExample: No examples of conditition lambda x: <unknown>
+  hypothesis.errors.NoSuchExample: No examples of condition lambda x: <unknown>
   >>> from hypothesis.strategies import booleans
   >>> find(booleans(), lambda x: False)
   Traceback (most recent call last):
   ...
-  hypothesis.errors.DefinitelyNoSuchExample: No examples of conditition lambda x: <unknown> (all 2 considered)
+  hypothesis.errors.DefinitelyNoSuchExample: No examples of condition lambda x: <unknown> (all 2 considered)
 
 
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -242,7 +242,7 @@ We could also have done this as a unittest TestCase:
 A detail: This works because Hypothesis ignores any arguments it hasn't been
 told to provide (positional arguments start from the right), so the self
 argument to the test is simply ignored and works as normal. This also means
-that Hypothesis will play nicely with other ways of parametrizing tests. e.g
+that Hypothesis will play nicely with other ways of parameterizing tests. e.g
 it works fine if you use pytest fixtures for some arguments and Hypothesis for
 others.
 

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -224,7 +224,7 @@ technical limitations, Hypothesis was unable to find that particular shrink.
 In general it's rare for examples produced to be long, but they won't always be
 minimal.
 
-You can control the deailed behaviour with a Settings object on the TestCase
+You can control the detailed behaviour with a Settings object on the TestCase
 (this is a normal hypothesis Settings object using the defaults at the time
 the TestCase class was first referenced). For example if you wanted to run
 fewer examples with larger programs you could change the settings to:

--- a/examples/bintree.py
+++ b/examples/bintree.py
@@ -386,7 +386,7 @@ class BinaryTreeStrategy(SearchStrategy):
         unlike the behaviour when our top level template is a leaf we use
         full_simplify. This is to prevent a combinatorial explosion: If we
         were to use all the individual simplifiers of the leaves we would
-        potentially have a very large numbeer of simplifiers to consider.
+        potentially have a very large number of simplifiers to consider.
 
         All full_simplify does is run each simplifier (albeit in a slightly
         randomized order), so we still get the same amount of simplification.

--- a/src/hypothesis/errors.py
+++ b/src/hypothesis/errors.py
@@ -67,7 +67,7 @@ class NoSuchExample(HypothesisException):
 
     def __init__(self, condition_string, extra=u''):
         super(NoSuchExample, self).__init__(
-            u'No examples found of conditition %s%s' % (
+            u'No examples found of condition %s%s' % (
                 condition_string, extra)
         )
 

--- a/src/hypothesis/searchstrategy/collections.py
+++ b/src/hypothesis/searchstrategy/collections.py
@@ -430,7 +430,7 @@ class SingleElementListStrategy(MappedSearchStrategy):
     template.
 
     This may seem like a ridiculous special case, but it's actually
-    worth doing: The reason is twowold: Firstly, we can be much more efficient
+    worth doing: The reason is twofold: Firstly, we can be much more efficient
     here. Secondly, the normal representation is super *in*efficient here for
     the problem of detecting duplicates, which are much more likely when there
     is only one element template.

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -335,7 +335,7 @@ def lists(
     elements=None, min_size=None, average_size=None, max_size=None,
     unique_by=None
 ):
-    """Returns a list containining values drawn from elements length in the
+    """Returns a list containing values drawn from elements length in the
     interval [min_size, max_size] (no bounds in that direction if these are
     None). If max_size is 0 then elements may be None and only the empty list
     will be drawn.

--- a/tests/cover/test_given_error_conditions.py
+++ b/tests/cover/test_given_error_conditions.py
@@ -51,7 +51,7 @@ def test_raises_unsatisfiable_if_all_false_in_finite_set():
         test_assume_false()
 
 
-def testt_does_not_raise_unsatisfiable_if_some_false_in_finite_set():
+def test_does_not_raise_unsatisfiable_if_some_false_in_finite_set():
     @given(booleans())
     def test_assume_x(x):
         assume(x)

--- a/tests/cover/test_simple_numbers.py
+++ b/tests/cover/test_simple_numbers.py
@@ -100,7 +100,7 @@ def test_can_find_standard_complex_numbers():
     find(complex_numbers(), lambda x: x.real != 0) == 1
 
 
-def test_minimial_float_is_zero():
+def test_minimal_float_is_zero():
     assert find(floats(), lambda x: True) == 0.0
 
 

--- a/tests/cover/test_simple_strings.py
+++ b/tests/cover/test_simple_strings.py
@@ -40,7 +40,7 @@ def test_can_handle_large_codepoints():
     assert s == u'☃'
 
 
-def test_can_find_mixed_ascii_and_non_ascii_stringgs():
+def test_can_find_mixed_ascii_and_non_ascii_strings():
     s = find(
         text(), lambda x: (
             any(t >= u'☃' for t in x) and

--- a/tests/nocover/test_example_quality.py
+++ b/tests/nocover/test_example_quality.py
@@ -57,7 +57,7 @@ def test_minimize_list_of_sets_on_large_structure():
     assert len(set(x)) == 1
 
 
-def test_integers_from_minizes_leftwards():
+def test_integers_from_minimizes_leftwards():
     assert minimal(integers(min_value=101)) == 101
 
 


### PR DESCRIPTION
@DRMacIver This pull request corrects several spelling errors I found using the [scspell](https://pypi.python.org/pypi/scspell) utility. I verified that none of the changes introduce any linting errors

The scspell utility has a fairly high false positive rate, labeling several differences between British and American English as errors. I ignored those "errors" manually. I think the corrections included here are unambiguous spelling errors or typos.  None of them have any effect on code execution, since they occurred in either documentation or test names.

I opted not to correct the following errors in `changes.rst` since immutability of changelogs is probably desirable.
  - simplificaiton
  - implemnetation
  - suitee
  - parametrizing
  - remaing
  - Mozila
  - stratagies
  - embarassing

Thanks for all the work you've put into the hypothesis library!