### PR TITLE
Fail Travis build quickly if a worker fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,3 +68,4 @@ matrix:
           env: TOXENV=coverage
         - os: osx
           env: TOXENV=lint
+    fast_finish: true


### PR DESCRIPTION
This avoids taking up resources when we're going to fail the build anyway, see
http://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing.