### PR TITLE
Retry flaky tests on fail

### DIFF
--- a/tests/cover/test_recursive.py
+++ b/tests/cover/test_recursive.py
@@ -18,6 +18,7 @@ from __future__ import division, print_function, absolute_import
 
 import pytest
 import hypothesis.strategies as st
+from flaky import flaky
 from hypothesis import find, given, Settings
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal.debug import timeout
@@ -151,6 +152,7 @@ def test_can_simplify_hard_recursive_data_into_boolean_alternative(rnd):
     assert all(isinstance(v, bool) for v in lvs), repr(lvs)
 
 
+@flaky(max_runs=5, min_passes=1)
 @given(st.randoms(), settings=Settings(max_examples=10))
 @timeout(60)
 def test_can_flatmap_to_recursive_data(rnd):

--- a/tests/cover/test_testdecorators.py
+++ b/tests/cover/test_testdecorators.py
@@ -27,6 +27,7 @@ from collections import namedtuple
 
 import hypothesis.settings as hs
 import hypothesis.reporting as reporting
+from flaky import flaky
 from hypothesis import given, assume
 from hypothesis.errors import Flaky, Unsatisfiable, InvalidArgument
 from tests.common.utils import fails, raises, fails_with, capture_out
@@ -564,6 +565,7 @@ def test_should_not_count_duplicates_towards_max_examples():
     assert len(seen) == 9
 
 
+@flaky(max_runs=10, min_passes=1)
 def test_can_timeout_during_an_unsuccessful_simplify():
     record = []
 

--- a/tests/nocover/test_example_quality.py
+++ b/tests/nocover/test_example_quality.py
@@ -23,6 +23,7 @@ from decimal import Decimal
 from fractions import Fraction
 
 import pytest
+from flaky import flaky
 from hypothesis import find, assume, Settings
 from tests.common import parametrize, ordered_pair, constant_list
 from hypothesis.strategies import just, sets, text, lists, binary, \
@@ -240,6 +241,7 @@ def test_can_simplify_on_both_sides_of_flatmap():
     ) == [0] * 10
 
 
+@flaky(max_runs=5, min_passes=1)
 def test_flatmap_rectangles():
     lengths = integers(min_value=0, max_value=10)
 
@@ -342,6 +344,7 @@ def test_non_reversible_fractions_as_decimals():
     assert len(sigh) <= 25
 
 
+@flaky(max_runs=5, min_passes=1)
 def test_non_reversible_decimals():
     def not_reversible(xs):
         assume(all(x.is_finite() for x in xs))

--- a/tests/numpy/test_gen_data.py
+++ b/tests/numpy/test_gen_data.py
@@ -19,6 +19,7 @@ from __future__ import division, print_function, absolute_import
 import numpy as np
 import pytest
 import hypothesis.strategies as st
+from flaky import flaky
 from hypothesis import find, given
 from hypothesis.extra.numpy import arrays, from_dtype
 from hypothesis.strategytests import strategy_test_suite
@@ -71,6 +72,7 @@ def test_can_minimize_large_arrays_easily():
     assert x.sum() == 1
 
 
+@flaky(max_runs=5, min_passes=1)
 def test_can_minimize_float_arrays():
     x = find(arrays(float, 50), lambda t: t.sum() >= 1.0)
     assert 1.0 <= x.sum() <= 1.1

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ passenv=HOME
 [testenv]
 deps =
     pytest==2.8.0
+    flaky
 whitelist_externals=
   bash
 setenv=
@@ -54,19 +55,25 @@ commands =
 
 [testenv:nose]
 basepython=python3.5
-deps = nose
+deps =
+    nose
+    flaky
 commands=
-    nosetests tests/cover/test_testdecorators.py
+    nosetests --with-flaky tests/cover/test_testdecorators.py
 
 [testenv:pytest27]
 basepython=python3.5
-deps = pytest==2.7.3
+deps =
+    pytest==2.7.3
+    flaky
 commands=
     python -m pytest tests/pytest tests/cover/test_testdecorators.py
 
 [testenv:pytest26]
 basepython=python2.7
-deps = pytest==2.6.3
+deps =
+    pytest==2.6.3
+    flaky
 commands=
     python -m pytest tests/cover/test_testdecorators.py
 
@@ -82,6 +89,7 @@ deps =
     coverage
     pytest==2.8.0
     pytz
+    flaky
 commands =
     coverage --version
     coverage debug sys


### PR DESCRIPTION
This adds "flaky" as a dependency. I've tagged all tests which failed in my
previous pull requests.