### PR TITLE
Fix bad interaction (restart loop) with web servers.

### DIFF
--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -365,22 +365,21 @@ def source_exec_as_module(source):
         )
         temporary_filepath = os.path.join(d, temporary_name + u'.py')
         final_filepath = os.path.join(d, final_name + u'.py')
-        f = open(temporary_filepath, u'w')
-        f.write(source)
-        f.close()
-        assert os.path.exists(temporary_filepath)
-
-        try:
-            os.rename(temporary_filepath, final_filepath)
-        except OSError:  # pragma: no cover
-            # The odds of final_filepath being a directory are basically zero,
-            # and it's basically impossible for them to be on different
-            # filesystems, so
-            # if this is raised it's because the destination already exists on
-            # Windows. That's fine, it won't be different, so just keep going,
-            # deleting our tempfile.
-            assert not os.path.isdir(final_filepath)
-            os.remove(temporary_filepath)
+        if not os.path.exists(final_filepath):
+            with open(temporary_filepath, u'w') as f:
+                f.write(source)
+            assert os.path.exists(temporary_filepath)
+            try:
+                os.rename(temporary_filepath, final_filepath)
+            except OSError:  # pragma: no cover
+                # The odds of final_filepath being a directory are basically zero,
+                # and it's basically impossible for them to be on different
+                # filesystems, so
+                # if this is raised it's because the destination already exists on
+                # Windows. That's fine, it won't be different, so just keep going,
+                # deleting our tempfile.
+                assert not os.path.isdir(final_filepath)
+                os.remove(temporary_filepath)
 
         assert os.path.exists(final_filepath)
         assert not os.path.exists(temporary_filepath)

--- a/src/hypothesis/internal/reflection.py
+++ b/src/hypothesis/internal/reflection.py
@@ -372,15 +372,16 @@ def source_exec_as_module(source):
             try:
                 os.rename(temporary_filepath, final_filepath)
             except OSError:  # pragma: no cover
-                # The odds of final_filepath being a directory are basically zero,
-                # and it's basically impossible for them to be on different
-                # filesystems, so
-                # if this is raised it's because the destination already exists on
-                # Windows. That's fine, it won't be different, so just keep going,
-                # deleting our tempfile.
+                # The odds of final_filepath being a directory are basically
+                # zero, and it's basically impossible for them to be on
+                # different filesystems, so if this is raised it's because
+                # the destination already exists on Windows. That's fine,
+                # it won't be different, so just keep going, deleting our
+                # tempfile.
                 assert not os.path.isdir(final_filepath)
                 os.remove(temporary_filepath)
-
+        else:
+            assert os.path.exists(final_filepath)
         assert os.path.exists(final_filepath)
         assert not os.path.exists(temporary_filepath)
         with open(final_filepath) as r:


### PR DESCRIPTION
This fixes an interaction with web servers that offer an automatic code reload option, eg. paster or gunicorn. These temp files would be written each time the server started, causing other servers to notice the change and restart, which in turn causes the original to notice the change and restart (and so on in a loop). This behaviour only appeared with multiple auto-reloading servers running in parallel.

I tried to keep the change minimal. It should be very low risk since the filename includes a hash of the content, so if it exists, there should be no reason overwriting it will change behaviour.