### PR TITLE
preconditions for RuleBasedStateMachine

### DIFF
--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -47,7 +47,7 @@ Rule based state machines
 
 Rule based state machines are the ones you're most likely to want to use.
 They're significantly more user friendly and should be good enough for most
-things you'd want to do. 
+things you'd want to do.
 
 A rule based state machine is a collection of functions (possibly with side
 effects) which may depend on both values that Hypothesis can generate and
@@ -236,6 +236,48 @@ fewer examples with larger programs you could change the settings to:
 
 Which doubles the number of steps each program runs and halves the number of
 runs relative to the example. settings.timeout will also be respected as usual.
+
+-------------
+Preconditions
+-------------
+
+While it's possible to use ``assume`` RuleBasedStateMachine rules, after only a
+few uses in a few rules you can quickly run into a situation where very few
+rules are actually executed successfully. Thus, Hypothesis provides a
+``precondition`` decorator to avoid this problem. The ``precondition``
+decorator is used by using it on a ``rule``-decorated function, and passing a
+function that returns True or False based on the RuleBasedStateMachine
+instance.
+
+.. code:: python
+
+    from hypothesis.stateful import RuleBasedStateMachine, rule
+
+    class NumberModifier(RuleBasedStateMachine):
+
+        num = 0
+
+        @rule()
+        def add_one(self):
+            self.num += 1
+
+        @rule()
+        def sub_one(self):
+            self.num -= 1
+
+        @precondition(lambda self: self.num != 0)
+        @rule()
+        def divide_with_one(self):
+            self.num = 1 / self.num
+
+
+By using ``precondition`` here instead of ``assume``, we make it much more
+likely that Hypothesis will generate a valid sequence of steps instead of
+pointlessly running steps that are skipped because of invalid assumptions.
+
+Note that preconditions can't look at data inside of a bundle; if you need to
+use preconditions, you should store your relevant data on your instances
+instead.
 
 ----------------------
 Generic state machines

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -237,7 +237,6 @@ fewer examples with larger programs you could change the settings to:
 Which doubles the number of steps each program runs and halves the number of
 runs relative to the example. settings.timeout will also be respected as usual.
 
--------------
 Preconditions
 -------------
 

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -251,7 +251,7 @@ instance.
 
 .. code:: python
 
-    from hypothesis.stateful import RuleBasedStateMachine, rule
+    from hypothesis.stateful import RuleBasedStateMachine, rule, precondition
 
     class NumberModifier(RuleBasedStateMachine):
 
@@ -284,7 +284,7 @@ Generic state machines
 ----------------------
 
 The class GenericStateMachine is the underlying machinery of stateful testing
-in Hypothesis. In execution it looks much like the RuleBasedStateMachine but 
+in Hypothesis. In execution it looks much like the RuleBasedStateMachine but
 it allows the set of steps available to depend in essentially arbitrary
 ways on what has happened so far. For example, if you wanted to
 use Hypothesis to test a game, it could choose each step in the machine based

--- a/docs/stateful.rst
+++ b/docs/stateful.rst
@@ -240,13 +240,12 @@ runs relative to the example. settings.timeout will also be respected as usual.
 Preconditions
 -------------
 
-While it's possible to use ``assume`` RuleBasedStateMachine rules, after only a
-few uses in a few rules you can quickly run into a situation where very few
-rules are actually executed successfully. Thus, Hypothesis provides a
+While it's possible to use ``assume`` in RuleBasedStateMachine rules, if you
+use it in only a few rules you can quickly run into a situation where few or
+none of your rules pass their assumptions. Thus, Hypothesis provides a
 ``precondition`` decorator to avoid this problem. The ``precondition``
-decorator is used by using it on a ``rule``-decorated function, and passing a
-function that returns True or False based on the RuleBasedStateMachine
-instance.
+decorator is used on ``rule``-decorated functions, and must be given a function
+that returns True or False based on the RuleBasedStateMachine instance.
 
 .. code:: python
 
@@ -260,23 +259,18 @@ instance.
         def add_one(self):
             self.num += 1
 
-        @rule()
-        def sub_one(self):
-            self.num -= 1
-
         @precondition(lambda self: self.num != 0)
         @rule()
         def divide_with_one(self):
             self.num = 1 / self.num
 
 
-By using ``precondition`` here instead of ``assume``, we make it much more
-likely that Hypothesis will generate a valid sequence of steps instead of
-pointlessly running steps that are skipped because of invalid assumptions.
+By using ``precondition`` here instead of ``assume``, Hypothesis can filter the
+inapplicable rules before running them. This makes it much more likely that a
+useful sequence of steps will be generated.
 
-Note that preconditions can't look at data inside of a bundle; if you need to
-use preconditions, you should store your relevant data on your instances
-instead.
+Note that currently preconditions can't access bundles; if you need to use
+preconditions, you should store relevant data on the instance instead.
 
 ----------------------
 Generic state machines

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -549,12 +549,32 @@ VarReference = namedtuple(u'VarReference', (u'name',))
 
 
 def precondition(precond):
+    """Decorator to apply a precondition for rules in a RuleBasedStateMachine.
+    Specifies a precondition for a rule to be considered as a valid step in the
+    state machine. The given function will be called with the instance of
+    RuleBasedStateMachine and should return True or False. Usually it will need
+    to look at attributes on that instance.
+
+    For example::
+
+        class MyTestMachine(RuleBasedStateMachine):
+            state = 1
+
+            @precondition(lambda self: self.state != 0)
+            @rule(numerator=integers())
+            def divide_with(self, numerator):
+                self.state = numerator / self.state
+
+    This is better than using assume in your rule since more valid rules
+    should be able to be run.
+
+    """
     def decorator(f):
         rule = getattr(f, RULE_MARKER, None)
         if rule is None:
             raise Exception(
-                "Can only use the `precondition` decorator on functions that "
-                "are already decorated with `rule`")
+                'Can only use the `precondition` decorator on functions that '
+                'are already decorated with `rule`')
         new_rule = Rule(targets=rule.targets, arguments=rule.arguments,
                         function=rule.function, precondition=precond,
                         parent_rule=rule.parent_rule)

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -26,7 +26,6 @@ execution to date.
 
 from __future__ import division, print_function, absolute_import
 
-import copy
 import inspect
 import traceback
 from random import Random
@@ -536,8 +535,10 @@ def rule(targets=(), target=None, precondition=None, **kwargs):
         parent_rule = getattr(f, RULE_MARKER, None)
         rule = Rule(targets=tuple(converted_targets), arguments=kwargs,
                     function=f, precondition=None, parent_rule=parent_rule)
+
         def rule_wrapper(*args, **kwargs):
             return f(*args, **kwargs)
+
         # TODO: copy function metadata onto new function
         setattr(rule_wrapper, RULE_MARKER, rule)
         return rule_wrapper
@@ -551,12 +552,16 @@ def precondition(precond):
     def decorator(f):
         rule = getattr(f, RULE_MARKER, None)
         if rule is None:
-            raise Exception("Can only use the `precondition` decorator on functions that are already decorated with `rule`")
+            raise Exception(
+                "Can only use the `precondition` decorator on functions that "
+                "are already decorated with `rule`")
         new_rule = Rule(targets=rule.targets, arguments=rule.arguments,
                         function=rule.function, precondition=precond,
                         parent_rule=rule.parent_rule)
+
         def precondition_wrapper(*args, **kwargs):
             return f(*args, **kwargs)
+
         setattr(precondition_wrapper, RULE_MARKER, new_rule)
         return precondition_wrapper
     return decorator

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -36,7 +36,7 @@ from hypothesis.core import find
 from hypothesis.errors import Flaky, NoSuchExample, InvalidDefinition, \
     UnsatisfiedAssumption
 from hypothesis.control import BuildContext
-from hypothesis.settings import Settings, Verbosity
+from hypothesis.settings import Settings, Verbosity, note_deprecation
 from hypothesis.reporting import report, verbose_report, current_verbosity
 from hypothesis.internal.compat import hrange, integer_types
 from hypothesis.internal.reflection import proxies
@@ -536,7 +536,13 @@ def rule(targets=(), target=None, **kwargs):
     def accept(f):
         parent_rule = getattr(f, RULE_MARKER, None)
         if parent_rule is not None:
-            print("there's a parent! deprecate this!!")
+            note_deprecation(
+                'Applying the ``rule`` decorator to a function that is '
+                'already decorated by ``rule`` is deprecated. Please assign '
+                'the result of the ``rule`` function to separate names in '
+                'your class.',
+                Settings.default,
+            )
         precondition = getattr(f, PRECONDITION_MARKER, None)
         rule = Rule(targets=tuple(converted_targets), arguments=kwargs,
                     function=f, precondition=precondition, parent_rule=parent_rule)

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -545,7 +545,8 @@ def rule(targets=(), target=None, **kwargs):
             )
         precondition = getattr(f, PRECONDITION_MARKER, None)
         rule = Rule(targets=tuple(converted_targets), arguments=kwargs,
-                    function=f, precondition=precondition, parent_rule=parent_rule)
+                    function=f, precondition=precondition,
+                    parent_rule=parent_rule)
 
         @proxies(f)
         def rule_wrapper(*args, **kwargs):

--- a/src/hypothesis/stateful.py
+++ b/src/hypothesis/stateful.py
@@ -537,10 +537,9 @@ def rule(targets=(), target=None, **kwargs):
         parent_rule = getattr(f, RULE_MARKER, None)
         if parent_rule is not None:
             note_deprecation(
-                'Applying the ``rule`` decorator to a function that is '
-                'already decorated by ``rule`` is deprecated. Please assign '
-                'the result of the ``rule`` function to separate names in '
-                'your class.',
+                'Applying the rule decorator to a function that is already '
+                'decorated by rule is deprecated. Please assign the result '
+                'of the rule function to separate names in your class.',
                 Settings.default,
             )
         precondition = getattr(f, PRECONDITION_MARKER, None)

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -173,10 +173,11 @@ class DepthCharge(object):
 class DepthMachine(RuleBasedStateMachine):
     charges = Bundle(u'charges')
 
-    @rule(targets=(charges,), child=charges)
-    @rule(targets=(charges,), child=none())
-    def charge(self, child):
-        return DepthCharge(child)
+    with Settings(strict=False):
+        @rule(targets=(charges,), child=charges)
+        @rule(targets=(charges,), child=none())
+        def charge(self, child):
+            return DepthCharge(child)
 
     @rule(check=charges)
     def is_not_too_deep(self, check):

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -185,6 +185,15 @@ class DepthMachine(RuleBasedStateMachine):
         assert check.depth < 3
 
 
+class MultipleRulesSameFuncMachine(RuleBasedStateMachine):
+
+    def myfunc(self, data):
+        print(data)
+
+    rule1 = rule(data=just(u"rule1data"))(myfunc)
+    rule2 = rule(data=just(u"rule2data"))(myfunc)
+
+
 class PreconditionMachine(RuleBasedStateMachine):
     num = 0
 
@@ -324,6 +333,15 @@ def test_bad_machines_fail(machine):
     print(v)
     assert u'Step #1' in v
     assert u'Step #50' not in v
+
+
+def test_multiple_rules_same_func():
+    test_class = MultipleRulesSameFuncMachine.TestCase
+    with capture_out() as o:
+        test_class().runTest()
+    output = o.getvalue()
+    assert 'rule1data' in output
+    assert 'rule2data' in output
 
 
 class GivenLikeStateMachine(GenericStateMachine):

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -201,6 +201,10 @@ class PreconditionMachine(RuleBasedStateMachine):
     def add_one(self):
         self.num += 1
 
+    @rule()
+    def set_to_zero(self):
+        self.num = 0
+
     @rule(num=integers())
     @precondition(lambda self: self.num != 0)
     def div_by_precondition_after(self, num):

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -26,10 +26,9 @@ from hypothesis import assume, Settings
 from hypothesis.errors import Flaky, BadData, InvalidDefinition
 from tests.common.utils import raises, capture_out
 from hypothesis.database import ExampleDatabase
-from hypothesis.stateful import rule, Bundle, StateMachineRunner, \
-    GenericStateMachine, RuleBasedStateMachine, \
-    run_state_machine_as_test, StateMachineSearchStrategy, \
-    precondition
+from hypothesis.stateful import rule, Bundle, precondition, \
+    StateMachineRunner, GenericStateMachine, RuleBasedStateMachine, \
+    run_state_machine_as_test, StateMachineSearchStrategy
 from hypothesis.strategies import just, none, lists, tuples, choices, \
     booleans, integers, sampled_from
 

--- a/tests/cover/test_stateful.py
+++ b/tests/cover/test_stateful.py
@@ -26,6 +26,7 @@ from hypothesis import assume, Settings
 from hypothesis.errors import Flaky, BadData, InvalidDefinition
 from tests.common.utils import raises, capture_out
 from hypothesis.database import ExampleDatabase
+from hypothesis.settings import HypothesisDeprecationWarning
 from hypothesis.stateful import rule, Bundle, precondition, \
     StateMachineRunner, GenericStateMachine, RuleBasedStateMachine, \
     run_state_machine_as_test, StateMachineSearchStrategy
@@ -566,3 +567,15 @@ def test_statemachine_equality():
     assert hash(StateMachineRunner(1, 1, 1)) == hash(
         StateMachineRunner(1, 1, 1))
     assert StateMachineRunner(1, 1, 1) != StateMachineRunner(1, 1, 2)
+
+
+def test_stateful_double_rule_is_deprecated(recwarn):
+    with Settings(strict=False):
+        class DoubleRuleMachine(RuleBasedStateMachine):
+
+            @rule(num=just(1))
+            @rule(num=just(2))
+            def whatevs(self, num):
+                pass
+
+    recwarn.pop(HypothesisDeprecationWarning)


### PR DESCRIPTION
This adds a `@precondition` decorator that you can use on your `@rule`-decorated functions to add preconditions to them. Rules that don't match preconditions will not be considered as a "step" in the state machine.

TODO:

- [x] docstring updates
- [x] prose documentation
- [x] tests (I was pretty much just using my own code as a test case; need to actually implement in-hypothesis unit tests for this feature).

