### PR TITLE
Doc fixes

### DIFF
--- a/src/hypothesis/settings.py
+++ b/src/hypothesis/settings.py
@@ -388,7 +388,7 @@ Settings.define_setting(
     u'timeout',
     default=60,
     description="""
-Once this amount of time has passed, falsify will terminate even
+Once this many seconds have passed, falsify will terminate even
 if it has not found many examples. This is a soft rather than a hard
 limit - Hypothesis won't e.g. interrupt execution of the called
 function to stop it. If this value is <= 0 then no timeout will be

--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -674,8 +674,10 @@ def builds(target, *args, **kwargs):
 @defines_strategy
 def recursive(base, extend, max_leaves=100):
     """
-    base: A strategy to start from
-    extend: A function which takes a strategy and returns a new strategy
+    base: A strategy to start from.
+
+    extend: A function which takes a strategy and returns a new strategy.
+
     max_leaves: The maximum number of elements to be drawn from base on a given
     run.
 


### PR DESCRIPTION
A couple of tiny documentation fixes for things I came across when re-reading the docs recently.

You can see the poorly formatted paragraph here: http://hypothesis.readthedocs.org/en/latest/data.html#hypothesis.strategies.recursive