### PR TITLE
Allows test suite to be run, with a dirty checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,9 @@ check-examples3: $(TOX) $(PY35)
 check-coverage: $(TOX) $(PY35)
 	$(TOX) -e coverage
 
-check: check-format check-coverage check-py26 check-py27 check-py33 check-py34 check-py35 check-pypy check-django check-pytest
+check-noformat: check-coverage check-py26 check-py27 check-py33 check-py34 check-py35 check-pypy check-django check-pytest
+
+check: check-format check-noformat
 
 check-fast: lint $(PY26) $(PY35) $(PYPY) $(TOX)
 	$(TOX) -e pypy-brief


### PR DESCRIPTION
`make check` runs the full battery of tests, including the format check.
However before running any test suites the `check-format` target runs, to
enforce code style - including that there are no uncommitted changes.

As a consequence `make check` is awkward to run before a commit.

`make check-noformat` is intended to remedy that.