### PR TITLE
Fix PendingDeprecationWarning: generator '__iter__' raised StopIteration

### DIFF
--- a/src/hypothesis/types.py
+++ b/src/hypothesis/types.py
@@ -80,8 +80,7 @@ class Stream(object):
         while i < len(self.fetched):
             yield self.fetched[i]
             i += 1
-        while True:
-            v = next(self.generator)
+        for v in self.generator:
             self.fetched.append(v)
             yield v
 

--- a/tests/cover/test_health_checks.py
+++ b/tests/cover/test_health_checks.py
@@ -18,10 +18,10 @@ from __future__ import division, print_function, absolute_import
 
 import time
 
-from flaky import flaky
 from pytest import raises
 
 import hypothesis.strategies as st
+from flaky import flaky
 from hypothesis import given, Settings
 from hypothesis.errors import FailedHealthCheck
 


### PR DESCRIPTION
This warning happens in 3.5+ due to PEP-479 that aims to distinguish
stop iteration from generator exit. Eventually, StopIteration exception
happens inside __iter__ method (assuming iteration) on picking next item
from generator what violates the new rules.

While this change marked as backward incompatible, the fix is quite
trivial to work with all Python versions and not introduce any
workarounds.

The well known trigger of this warning are composite strategies, but
there may be others.

Notice: nose and py.test keeps silent on this warning, so you may notice
it if use stdlib unittest runner or similar.