### PR TITLE
Remove vestigial tests_require.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,4 @@ setup(
         'pytest11': ['hypothesispytest = hypothesis.extra.pytestplugin'],
     },
     long_description=open(README).read(),
-    tests_require=[
-        'pytest', 'flake8'],
 )


### PR DESCRIPTION
Given that `python setup.py test` doesn't work, we probably don't need this.