### PR TITLE
Fix settings example

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -79,18 +79,19 @@ of verbose output are, well, verbose, but they should convey the idea).
     >>> test_foo()
     Trying example: test_foo(x=-565872324465712963891750807252490657219)
     Traceback (most recent call last):
-      ...
+        ...
+        File "<stdin>", line 3, in test_foo
     AssertionError
     Trying example: test_foo(x=565872324465712963891750807252490657219)
     Trying example: test_foo(x=0)
     Traceback (most recent call last):
-    ...
+        ...
+        File "<stdin>", line 3, in test_foo
     AssertionError
     Falsifying example: test_foo(x=0)
     Traceback (most recent call last):
-    ...
+        ...
     AssertionError
-
 
 The four levels are quiet, normal, verbose and debug. normal is the default,
 while in quiet Hypothesis will not print anything out, even the final

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -71,9 +71,8 @@ of verbose output are, well, verbose, but they should convey the idea).
     Shrunk example to [True]
     [True]
     >>> from hypothesis import given
-    >>> from hypothesis.strategies import integers()
-    >>> settings.default.verbosity = Verbosity.verbose
-    >>> @given(integers())
+    >>> from hypothesis.strategies import integers
+    >>> @given(integers(), settings=settings(verbosity=Verbosity.verbose))
     ... def test_foo(x):
     ...     assert x > 0
     ...


### PR DESCRIPTION
The default settings are immutable, so to change verbosity you need to pass
your own instance instead of direct assignment.