### PR TITLE
Use pickle instead of marshal and test the caching.

### DIFF
--- a/src/hypothesis/internal/charstree.py
+++ b/src/hypothesis/internal/charstree.py
@@ -20,11 +20,11 @@ import os
 import sys
 import zlib
 import bisect
+import pickle
 import functools
 import itertools
 import unicodedata
 
-import marshal
 from hypothesis.errors import InvalidArgument
 from hypothesis._settings import hypothesis_home_dir
 from hypothesis.internal.compat import hrange, hunichr, OrderedDict
@@ -298,13 +298,13 @@ def cache_file_path():
                         os.path.basename(__file__) + '.cache')
 
 
-def dump_tree(tree):  # pragma: no cover
-    dump = marshal.dumps(tree, version=2)
+def dump_tree(tree):
+    dump = pickle.dumps(tree, pickle.HIGHEST_PROTOCOL)
     with open(cache_file_path(), 'wb') as f:
         f.write(zlib.compress(dump))
 
 
-def load_tree():  # pragma: no cover
+def load_tree():
     with open(cache_file_path(), 'rb') as f:
         dump = zlib.decompress(f.read())
-    return marshal.loads(dump)
+    return pickle.loads(dump)

--- a/tests/cover/test_charstree.py
+++ b/tests/cover/test_charstree.py
@@ -37,6 +37,12 @@ def test_unicode_tree():
     assert isinstance(tree, dict)
 
 
+def test_unicode_tree_cache():
+    tree = charstree.make_tree()
+    charstree.dump_tree(tree)
+    assert tree == charstree.load_tree()
+
+
 def test_ascii_tree_categories():
     tree = charstree.ascii_tree()
     expected = list(set([unicodedata.category(hunichr(i))


### PR DESCRIPTION
This fixes the cache for Python 3.x.

It makes a notable difference in startup time whether cache works or not.