### PR TITLE
Sort dependencies for stable ordering.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ extras = {
     'pytest': ['pytest>=2.7.0'],
 }
 
-extras['all'] = sum(extras.values(), [])
+extras['all'] = sorted(sum(extras.values(), []))
 extras['django'].extend(extras['fakefactory'])
 extras[":python_version == '2.6'"] = [
     'importlib', 'ordereddict', 'Counter', 'enum34']


### PR DESCRIPTION
This fixes a [reproducibility issue](https://tests.reproducible-builds.org/dbd/unstable/amd64/python-hypothesis_3.0.0-1.diffoscope.html#python3-hypothesis_3.0.0-1_all.deb/data.tar.xz/data.tar/./usr/lib/python3/dist-packages/hypothesis-3.0.0.egg-info/requires.txt) with building Hypothesis.