### PR TITLE
Also depend on enum34 for Python 3.3

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -147,6 +147,7 @@ their individual contributions.
 * `kbara <https://www.github.com/kbara>`_
 * `marekventur <https://www.github.com/marekventur>`_
 * `Marius Gedminas <https://www.github.com/mgedmin>`_ (`marius@gedmin.as <mailto:marius@gedmin.as>`_)
+* `Markus Unterwaditzer <http://github.com/untitaker/>`_ (`markus@unterwaditzer.net <mailto:markus@unterwaditzer.net>`_)
 * `Matt Bachmann <https://www.github.com/bachmann1234>`_ (`bachmann.matt@gmail.com <mailto:bachmann.matt@gmail.com>`_)
 * `Nicholas Chammas <https://www.github.com/nchammas>`_
 * `Richard Boulton <https://www.github.com/rboulton>`_ (`richard@tartarus.org <mailto:richard@tartarus.org>`_)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ extras[":python_version == '2.6'"] = [
     'importlib', 'ordereddict', 'Counter', 'enum34']
 
 extras[":python_version == '2.7'"] = ['enum34']
+extras[":python_version == '3.3'"] = ['enum34']
 
 
 setup(


### PR DESCRIPTION
I understand that this version is not really supported, but I thought it'd be trivial enough to add.