### PR TITLE
Fix supported versions in packaging guidelines

### DIFF
--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -38,9 +38,7 @@ Python versions
 Hypothesis is designed to work with a range of Python versions. Currently supported are:
 
 * pypy-2.6.1 (earlier versions of pypy *may* work)
-* CPython 2.6.x
 * CPython 2.7.x
-* CPython 3.3.x
 * CPython 3.4.x
 * CPython 3.5.x
 


### PR DESCRIPTION
The README says that the only supported versions are 2.7, 3.4 and 3.5.