### PR TITLE
Don't crash on pytest dev version

### DIFF
--- a/src/hypothesis/extra/pytestplugin.py
+++ b/src/hypothesis/extra/pytestplugin.py
@@ -22,11 +22,10 @@ import pytest
 
 from hypothesis.reporting import default as default_reporter
 
-PYTEST_VERSION = tuple(
-    map(
-        int,
-        re.sub('-.+', '', pytest.__version__).split('.')
-    ))[:3]
+PYTEST_VERSION = tuple(map(
+    int,
+    re.sub('-.+', '', pytest.__version__).split('.')[:3]
+))
 
 LOAD_PROFILE_OPTION = '--hypothesis-profile'
 


### PR DESCRIPTION
py.test has dev versions of the format `1.2.3.dev1`. `dev1` is not a
valid integer.