### PR TITLE
Remove duplicated __all__ exports

### DIFF
--- a/src/hypothesis/strategies.py
+++ b/src/hypothesis/strategies.py
@@ -45,7 +45,6 @@ __all__ = [
     'randoms', 'random_module',
     'recursive', 'composite',
     'shared', 'runner',
-    'recursive', 'composite',
 ]
 
 _strategies = set()


### PR DESCRIPTION
These seem to have been introduced accidentally in 2d195a0,
and seem to cause Sphinx to duplicate their automodule documentation,
as can be seen here:

http://hypothesis.readthedocs.org/en/3.1.0/data.html#hypothesis.strategies.recursive
http://hypothesis.readthedocs.org/en/3.1.0/data.html#hypothesis.strategies.composite