### PR TITLE
Add PyPy to Open Sources projects.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -25,6 +25,7 @@ then it should be available on pypi.
 * `natsort <https://github.com/SethMMorton/natsort>`_
 * `pretext <https://github.com/moreati/b-prefix-all-the-doctests>`_
 * `priority <https://github.com/python-hyper/priority>`_
+* `PyPy <http://pypy.org>`_
 * `pyrsistent <https://github.com/tobgu/pyrsistent>`_
 * `pyudev <https://github.com/pyudev/pyudev>`_
 * `qutebrowser <https://github.com/The-Compiler/qutebrowser>`_


### PR DESCRIPTION
According to this blog post (http://morepypy.blogspot.com.es/2016/03/pypy-50-released.html) PyPy 5.0 uses hypothesis for his tests.